### PR TITLE
Add SPI transport for MicroPython and Arduino

### DIFF
--- a/cpp/src/transport/SPITransport.cpp
+++ b/cpp/src/transport/SPITransport.cpp
@@ -1,0 +1,31 @@
+#include "SPITransport.h"
+
+void SPITransport::write(const uint8_t* data, size_t len) {
+    _bus.beginTransaction(_settings);
+    digitalWrite(_cs_pin, LOW);
+    for (size_t i = 0; i < len; i++)
+        _bus.transfer(data[i]);
+    digitalWrite(_cs_pin, HIGH);
+    _bus.endTransaction();
+}
+
+void SPITransport::read(uint8_t* buf, size_t len) {
+    _bus.beginTransaction(_settings);
+    digitalWrite(_cs_pin, LOW);
+    for (size_t i = 0; i < len; i++)
+        buf[i] = _bus.transfer(0x00);
+    digitalWrite(_cs_pin, HIGH);
+    _bus.endTransaction();
+}
+
+void SPITransport::write_read(const uint8_t* data, size_t data_len,
+                               uint8_t* buf, size_t buf_len) {
+    _bus.beginTransaction(_settings);
+    digitalWrite(_cs_pin, LOW);
+    for (size_t i = 0; i < data_len; i++)
+        _bus.transfer(data[i]);
+    for (size_t i = 0; i < buf_len; i++)
+        buf[i] = _bus.transfer(0x00);
+    digitalWrite(_cs_pin, HIGH);
+    _bus.endTransaction();
+}

--- a/cpp/src/transport/SPITransport.h
+++ b/cpp/src/transport/SPITransport.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <SPI.h>
+#include "Transport.h"
+
+class SPITransport : public Transport {
+public:
+    SPITransport(SPIClass& bus, uint8_t cs_pin, SPISettings settings)
+        : _bus(bus), _cs_pin(cs_pin), _settings(settings) {
+        pinMode(_cs_pin, OUTPUT);
+        digitalWrite(_cs_pin, HIGH);
+    }
+
+    void write(const uint8_t* data, size_t len) override;
+    void read(uint8_t* buf, size_t len) override;
+    void write_read(const uint8_t* data, size_t data_len,
+                    uint8_t* buf, size_t buf_len) override;
+
+private:
+    SPIClass&   _bus;
+    uint8_t     _cs_pin;
+    SPISettings _settings;
+};

--- a/python/periph/__init__.py
+++ b/python/periph/__init__.py
@@ -1,1 +1,1 @@
-from .transport import Transport, I2CTransport
+from .transport import Transport, I2CTransport, SPITransport

--- a/python/periph/transport/__init__.py
+++ b/python/periph/transport/__init__.py
@@ -1,2 +1,3 @@
 from .base import Transport
 from .i2c import I2CTransport
+from .spi import SPITransport

--- a/python/periph/transport/spi.py
+++ b/python/periph/transport/spi.py
@@ -1,0 +1,27 @@
+from .base import Transport
+
+
+class SPITransport(Transport):
+    def __init__(self, bus, cs):
+        self._bus = bus
+        self._cs = cs
+        self._cs.value(1)
+
+    def write(self, data):
+        self._cs.value(0)
+        self._bus.write(data)
+        self._cs.value(1)
+
+    def read(self, n):
+        self._cs.value(0)
+        result = self._bus.read(n)
+        self._cs.value(1)
+        return result
+
+    def write_read(self, data, n):
+        buf = bytearray(n)
+        self._cs.value(0)
+        self._bus.write(data)
+        self._bus.readinto(buf)
+        self._cs.value(1)
+        return bytes(buf)

--- a/specs/transport_spi.md
+++ b/specs/transport_spi.md
@@ -1,0 +1,56 @@
+# Transport Spec: SPI
+
+**Protocol:** SPI (Serial Peripheral Interface)  
+**Reference:** Motorola SPI Block Guide v03.06
+
+## Overview
+
+SPI is a four-wire full-duplex bus (MOSI, MISO, SCK, CS). Each device gets its own CS pin; the transport instance owns one CS pin and represents one device. Used when a chip lists SPI as a supported transport.
+
+## Interface Contract
+
+Identical to the I²C contract — chip drivers use the same three operations regardless of transport. CS is managed internally; callers never touch it.
+
+| Operation | Parameters | Returns | Notes |
+|-----------|------------|---------|-------|
+| `write` | `data: bytes` | — | Assert CS, send data, deassert CS |
+| `read` | `n: int` | `bytes` | Assert CS, clock out n dummy bytes, capture response, deassert CS |
+| `write_read` | `data: bytes, n: int` | `bytes` | Assert CS, send data, clock out n bytes, deassert CS; used for register reads |
+
+## Configuration Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `bus` | platform object | Configured `machine.SPI` (MicroPython) or `SPIClass&` (Arduino) |
+| `cs` | pin | CS pin — `machine.Pin` (MicroPython) or pin number `uint8_t` (Arduino) |
+| `baudrate` / `clock_hz` | int | Clock frequency in Hz (MicroPython only; Arduino uses `SPISettings`) |
+
+For Arduino, clock speed, bit order, and data mode are passed as an `SPISettings` object at construction time.
+
+CS idles high. Asserted low for the duration of each operation.
+
+## Platform Notes
+
+### MicroPython
+
+Wraps `machine.SPI`. CS is a `machine.Pin` driven manually.
+
+| Contract | MicroPython |
+|----------|-------------|
+| `write` | `cs(0)` → `spi.write(data)` → `cs(1)` |
+| `read` | `cs(0)` → `spi.read(n)` → `cs(1)` |
+| `write_read` | `cs(0)` → `spi.write(data)` → `spi.readinto(buf)` → `cs(1)` |
+
+Constructor accepts a `machine.SPI` or `machine.SoftSPI` instance and a `machine.Pin` for CS.
+
+### Arduino
+
+Wraps `SPIClass` (the global `SPI` object or any other `TwoWire` instance for boards with multiple SPI buses). Uses `beginTransaction` / `endTransaction` to support shared-bus operation correctly.
+
+| Contract | Arduino |
+|----------|---------|
+| `write` | `beginTransaction` → `digitalWrite(cs, LOW)` → `transfer` loop → `digitalWrite(cs, HIGH)` → `endTransaction` |
+| `read` | same framing, transfer dummy `0x00` bytes |
+| `write_read` | same framing, write phase then read phase |
+
+Constructor accepts a `SPIClass&`, a CS pin number, and an `SPISettings` (clock, bit order, data mode).


### PR DESCRIPTION
## Summary

- Implements `SPITransport` for MicroPython (wraps `machine.SPI`) and Arduino (wraps `SPIClass`)
- CS pin is managed internally — asserted low for the duration of each operation, idle high
- Arduino implementation uses `beginTransaction` / `endTransaction` for correct shared-bus behaviour
- Adds `specs/transport_spi.md` documenting the contract and platform mapping

## Test plan

- [ ] MicroPython: construct `SPITransport(machine.SPI(...), cs_pin)`, verify CS toggling and data on a logic analyser or known device
- [ ] Arduino: construct `SPITransport(SPI, cs_pin, SPISettings(...))`, verify `beginTransaction` / `endTransaction` framing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)