### PR TITLE
Fix I2CTransport.write_read for MicroPython

### DIFF
--- a/python/periph/transport/i2c.py
+++ b/python/periph/transport/i2c.py
@@ -14,5 +14,6 @@ class I2CTransport(Transport):
 
     def write_read(self, data, n):
         buf = bytearray(n)
-        self._bus.writeto_then_readfrom(self._addr, data, buf)
+        self._bus.writeto(self._addr, data, False)  # False = no STOP → repeated start
+        self._bus.readfrom_into(self._addr, buf)
         return bytes(buf)


### PR DESCRIPTION
## Summary

`writeto_then_readfrom` is a CircuitPython (`busio.I2C`) method — it does not exist in MicroPython's `machine.I2C`. The correct MicroPython approach is `writeto(addr, data, False)` (no STOP = repeated start) followed by `readfrom_into`.

Also verified that the other two methods are correct for MicroPython:
- `write`: `writeto(addr, buf)` ✓
- `read`: `readfrom(addr, n)` ✓ — note CircuitPython has no `readfrom`, only `readfrom_into`

## Verified on hardware

NUCLEO-F439ZI (STM32F439, MicroPython 1.27.0) + INA226 at 0x40 — all `INA226Minimal` and `INA226Full` methods pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)