### PR TITLE
Add INA226 Node-RED nodes

### DIFF
--- a/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/ina226.html
+++ b/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/ina226.html
@@ -1,0 +1,88 @@
+<!-- Config node: one instance per physical device -->
+<script type="text/javascript">
+    RED.nodes.registerType('ina226-device', {
+        category: 'config',
+        defaults: {
+            name:       { value: '' },
+            bus:        { value: '1', required: true, validate: RED.validators.number() },
+            address:    { value: '40', required: true },
+            rShunt:     { value: '0.1', required: true, validate: RED.validators.number() },
+            maxCurrent: { value: '2.0', required: true, validate: RED.validators.number() }
+        },
+        label: function() {
+            return this.name || ('INA226 @ 0x' + this.address + ' (bus ' + this.bus + ')');
+        }
+    });
+</script>
+
+<script type="text/html" data-template-name="ina226-device">
+    <div class="form-row">
+        <label for="node-config-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-config-input-name" placeholder="INA226">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-bus"><i class="fa fa-microchip"></i> I²C bus</label>
+        <input type="number" id="node-config-input-bus" min="0" style="width:80px"> &nbsp;(Linux /dev/i2c-N)
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-address">Address (hex)</label>
+        <input type="text" id="node-config-input-address" placeholder="40" style="width:80px"> &nbsp;default: 40 (0x40)
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-rShunt">R<sub>shunt</sub> (Ω)</label>
+        <input type="number" id="node-config-input-rShunt" min="0.001" step="0.001" style="width:100px">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-maxCurrent">Max current (A)</label>
+        <input type="number" id="node-config-input-maxCurrent" min="0.001" step="0.1" style="width:100px">
+    </div>
+</script>
+
+<!-- Read node: trigger → measurements -->
+<script type="text/javascript">
+    RED.nodes.registerType('ina226', {
+        category:  'Periph',
+        color:     '#a6bbcf',
+        defaults: {
+            name:   { value: '' },
+            device: { value: '', type: 'ina226-device', required: true }
+        },
+        inputs:  1,
+        outputs: 1,
+        icon:    'font-awesome/fa-bolt',
+        label:   function() { return this.name || 'INA226'; },
+        paletteLabel: 'INA226'
+    });
+</script>
+
+<script type="text/html" data-template-name="ina226">
+    <div class="form-row">
+        <label for="node-input-device"><i class="fa fa-microchip"></i> Device</label>
+        <input type="text" id="node-input-device">
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="INA226">
+    </div>
+</script>
+
+<script type="text/html" data-help-name="ina226">
+    <p>Reads voltage, current, power, and shunt voltage from an INA226 power monitor over I²C.</p>
+    <p>Any input message triggers a measurement. The device is configured via an <b>ina226-device</b> config node.</p>
+
+    <h3>Output</h3>
+    <dl class="message-properties">
+        <dt>payload.voltage <span class="property-type">number</span></dt>
+        <dd>Bus voltage in volts.</dd>
+        <dt>payload.current <span class="property-type">number</span></dt>
+        <dd>Current in amperes. Requires correct R<sub>shunt</sub> and max current in the device config.</dd>
+        <dt>payload.power <span class="property-type">number</span></dt>
+        <dd>Power in watts.</dd>
+        <dt>payload.shuntVoltage <span class="property-type">number</span></dt>
+        <dd>Shunt voltage in volts.</dd>
+    </dl>
+
+    <h3>Details</h3>
+    <p>Configure bus number, I²C address (default <code>0x40</code>), shunt resistance, and maximum expected
+    current in the device config node. The driver uses these to set the calibration register on startup.</p>
+</script>

--- a/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/ina226.html
+++ b/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/ina226.html
@@ -41,7 +41,7 @@
 <!-- Read node: trigger → measurements -->
 <script type="text/javascript">
     RED.nodes.registerType('ina226', {
-        category:  'Periph',
+        category:  RED._('ina226:category'),
         color:     '#a6bbcf',
         defaults: {
             name:   { value: '' },

--- a/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/ina226.html
+++ b/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/ina226.html
@@ -41,7 +41,7 @@
 <!-- Read node: trigger → measurements -->
 <script type="text/javascript">
     RED.nodes.registerType('ina226', {
-        category:  RED._('ina226:category'),
+        category:  'Peripheral',
         color:     '#a6bbcf',
         defaults: {
             name:   { value: '' },

--- a/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/ina226.js
+++ b/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/ina226.js
@@ -1,0 +1,50 @@
+'use strict';
+
+module.exports = function(RED) {
+    const { I2CTransport } = require('periph/src/transport/i2c');
+    const { INA226Full }   = require('periph/src/chips/power/ina226');
+
+    function INA226DeviceNode(config) {
+        RED.nodes.createNode(this, config);
+        const node = this;
+        try {
+            const transport = new I2CTransport(parseInt(config.bus), parseInt(config.address, 16));
+            node.driver    = new INA226Full(transport, parseFloat(config.rShunt), parseFloat(config.maxCurrent));
+            node.transport = transport;
+        } catch (e) {
+            node.error('INA226 init failed: ' + e.message);
+        }
+        node.on('close', function() {
+            if (node.transport) node.transport.close();
+        });
+    }
+    RED.nodes.registerType('ina226-device', INA226DeviceNode);
+
+    function INA226ReadNode(config) {
+        RED.nodes.createNode(this, config);
+        const node = this;
+        node.device = RED.nodes.getNode(config.device);
+
+        node.on('input', function(msg, send, done) {
+            if (!node.device || !node.device.driver) {
+                node.error('No INA226 device configured', msg);
+                done();
+                return;
+            }
+            try {
+                const d = node.device.driver;
+                msg.payload = {
+                    voltage:      d.voltage(),
+                    current:      d.current(),
+                    power:        d.power(),
+                    shuntVoltage: d.shuntVoltage()
+                };
+                send(msg);
+                done();
+            } catch (e) {
+                done(e);
+            }
+        });
+    }
+    RED.nodes.registerType('ina226', INA226ReadNode);
+};

--- a/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/locales/de/ina226.json
+++ b/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/locales/de/ina226.json
@@ -1,0 +1,3 @@
+{
+    "category": "Peripherie"
+}

--- a/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/locales/de/ina226.json
+++ b/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/locales/de/ina226.json
@@ -1,3 +1,0 @@
-{
-    "category": "Peripherie"
-}

--- a/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/locales/en-US/ina226.json
+++ b/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/locales/en-US/ina226.json
@@ -1,3 +1,0 @@
-{
-    "category": "Peripheral"
-}

--- a/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/locales/en-US/ina226.json
+++ b/nodejs/packages/node-red-contrib-periph-power/nodes/ina226/locales/en-US/ina226.json
@@ -1,0 +1,3 @@
+{
+    "category": "Peripheral"
+}

--- a/nodejs/packages/node-red-contrib-periph-power/package.json
+++ b/nodejs/packages/node-red-contrib-periph-power/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "node-red": {
     "nodes": {
-      "periph-power": "index.js"
+      "ina226": "nodes/ina226/ina226.js"
     }
   },
   "dependencies": {

--- a/nodejs/packages/node-red-contrib-periph-power/package.json
+++ b/nodejs/packages/node-red-contrib-periph-power/package.json
@@ -3,8 +3,11 @@
   "version": "0.1.0",
   "description": "Node-RED nodes for power monitor chips",
   "keywords": ["node-red", "power", "i2c", "spi", "sensor", "peripheral"],
+  "main": "index.js",
   "node-red": {
-    "nodes": {}
+    "nodes": {
+      "periph-power": "index.js"
+    }
   },
   "dependencies": {
     "periph": "*"


### PR DESCRIPTION
## Summary

- Adds `ina226-device` config node: holds bus number, I²C address, shunt resistance, and max current; owns the `INA226Full` driver instance lifecycle
- Adds `ina226` read node: any input triggers a measurement; outputs `msg.payload` with `voltage`, `current`, `power`, and `shuntVoltage`
- Wires `node-red-contrib-periph-power/package.json` to the auto-discovery `index.js` so Node-RED picks up the nodes on install

## Test plan

- [ ] `node -e "require('./packages/node-red-contrib-periph-power/index.js')({nodes:{createNode:()=>{},registerType:(n)=>console.log(n),getNode:()=>null},validators:{number:()=>()=>true}})"` logs `ina226-device` and `ina226`
- [ ] Install package in a Node-RED instance, confirm both nodes appear in the Periph palette category
- [ ] Wire inject → ina226 → debug, configure device on /dev/i2c-15 at 0x40, confirm payload contains voltage/current/power/shuntVoltage

🤖 Generated with [Claude Code](https://claude.com/claude-code)