### PR TITLE
ci: upgrade Node.js from 20 to 24 in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: nodejs/package-lock.json
 


### PR DESCRIPTION
Node.js 20 actions are deprecated by GitHub; 24 is the current LTS.