### PR TITLE
chore: add pyrightconfig.json and jsconfig.json for LSP support

### DIFF
--- a/nodejs/jsconfig.json
+++ b/nodejs/jsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "checkJs": true,
+    "strictNullChecks": true
+  },
+  "include": [
+    "packages/*/src/**/*.js",
+    "packages/*/nodes/**/*.js",
+    "packages/*/index.js",
+    "packages/*/examples/**/*.js"
+  ],
+  "exclude": [
+    "**/node_modules"
+  ]
+}

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,14 @@
+{
+  "include": [
+    "python/periph",
+    "python/examples",
+    "python/tests"
+  ],
+  "exclude": [
+    "python/**/__pycache__"
+  ],
+  "pythonVersion": "3.11",
+  "typeCheckingMode": "basic",
+  "reportMissingImports": "warning",
+  "reportMissingModuleSource": "warning"
+}


### PR DESCRIPTION
## Summary

- Adds `pyrightconfig.json` at the repo root to enable Pyright/Pylance LSP support for the Python package (`python/periph`, examples, tests)
- Adds `nodejs/jsconfig.json` to enable JS language server support across all Node.js workspace packages
- C++ and Rust LSP support left out intentionally: C++ needs a build system first, Rust works out of the box via rust-analyzer

## Test plan

- [ ] Open a Python file in `python/periph/` — verify go-to-definition and type diagnostics work in your IDE
- [ ] Open a JS file in `nodejs/packages/periph/src/` — verify completion and null-check diagnostics work

🤖 Generated with [Claude Code](https://claude.com/claude-code)