### PR TITLE
feat(jvm): JVM (Java/Kotlin/Groovy) target via Pi4J

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ cpp/testconfig_zephyr
 .claude/
 rust/testconfig
 rust/testconfig_esp32s3
+jvm/testconfig
 rust/target/
 rust/tests/power/ina226_test_esp32s3/target/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Implementations:
 - **C++** — Arduino, Linux GCC, and Zephyr RTOS
 - **Node.js / Node-RED** — plain JS drivers (`periph` npm package) + per-category Node-RED node packages (`node-red-contrib-periph-<category>`)
 - **Rust** — two targets: Linux host (via `linux-embedded-hal`) and ESP32-S3 bare-metal (via `esp-hal`); generic over `embedded-hal` 1.0
+- **Java / Kotlin / Groovy** — JVM target: Raspberry Pi via Pi4J; transports in Java (shared by all three); drivers in Java, Kotlin, and Groovy
 
 ## Workflow
 
@@ -137,6 +138,46 @@ rust/
     <category>/
       <chip>_test/      # Linux integration test crate
       <chip>_test_esp32s3/  # ESP32-S3 smoke test (excluded from workspace)
+jvm/
+  pom.xml               # Parent POM: groupId=it.uhde, artifactId=periph, multi-module
+  periph-transport/     # Java-only transport library (JPMS module: it.uhde.periph.transport)
+    src/main/java/
+      module-info.java          # exports it.uhde.periph.transport; requires com.pi4j
+      it/uhde/periph/transport/ # Transport interface + Pi4J I2C/SPI implementations
+    pom.xml
+  periph-java/          # Java chip drivers (JPMS module: it.uhde.periph)
+    src/
+      main/java/
+        module-info.java        # exports it.uhde.periph.chips.*; requires it.uhde.periph.transport
+        it/uhde/periph/chips/
+          <category>/   # One class per chip, grouped by category
+      test/java/
+    pom.xml
+  periph-kotlin/        # Kotlin chip drivers (kotlin-maven-plugin; no JPMS)
+    src/
+      main/kotlin/
+        it/uhde/periph/chips/
+          <category>/   # One class per chip, grouped by category
+      test/kotlin/
+    pom.xml
+  periph-groovy/        # Groovy chip drivers (gmavenplus-plugin; no JPMS)
+    src/
+      main/groovy/
+        it/uhde/periph/chips/
+          <category>/   # One class per chip, grouped by category
+      test/groovy/
+    pom.xml
+  examples/
+    java/
+      <category>/
+        <chip>/         # Minimal.java, Complete.java, Demo.java
+    kotlin/
+      <category>/
+        <chip>/         # Minimal.kt, Complete.kt, Demo.kt
+    groovy/
+      <category>/
+        <chip>/         # Minimal.groovy, Complete.groovy, Demo.groovy
+  tests/
 ```
 
 Each chip driver depends only on the transport abstraction, never on a concrete bus.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,17 +167,19 @@ jvm/
           <category>/   # One class per chip, grouped by category
       test/groovy/
     pom.xml
-  examples/
+  examples/             # JBang scripts — run with: jbang Minimal.java (or .kt / .groovy)
     java/
       <category>/
-        <chip>/         # Minimal.java, Complete.java, Demo.java
+        <chip>/         # Minimal.java, Complete.java, Demo.java  (//DEPS it.uhde:periph-java:...)
     kotlin/
       <category>/
-        <chip>/         # Minimal.kt, Complete.kt, Demo.kt
+        <chip>/         # Minimal.kt, Complete.kt, Demo.kt        (//DEPS it.uhde:periph-kotlin:...)
     groovy/
       <category>/
-        <chip>/         # Minimal.groovy, Complete.groovy, Demo.groovy
-  tests/
+        <chip>/         # Minimal.groovy, Complete.groovy, Demo.groovy (//DEPS it.uhde:periph-groovy:...)
+  tests/                # JBang integration test scripts (run on Pi hardware)
+    <category>/
+      <chip>/           # <chip>Test.java (or .kt / .groovy)  (//DEPS it.uhde:periph-java:...)
 ```
 
 Each chip driver depends only on the transport abstraction, never on a concrete bus.

--- a/jvm/examples/groovy/adc_dac/mcp4725/Complete.groovy
+++ b/jvm/examples/groovy/adc_dac/mcp4725/Complete.groovy
@@ -1,0 +1,55 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.adc_dac.Mcp4725Full
+
+def pi4j = Pi4J.newAutoContext()                                    // initialise Pi4J, () → Context
+try {
+    def transport   = new I2CTransport(pi4j, 1, 0x60)              // open device transport, (bus, address) → I2CTransport
+    def gcTransport = new I2CTransport(pi4j, 1, 0x00)              // open general call transport, (bus, address=0x00) → I2CTransport
+    try {
+        def dac = new Mcp4725Full(transport, gcTransport)           // construct driver, (transport, generalCall) → Mcp4725Full
+
+        dac.setVoltage(0.5)                                         // set output to 50% of VDD, (fraction=0.0–1.0) → void
+                                                                    // converts fraction to 12-bit code and issues a Fast Write
+        dac.setRaw(2048)                                            // set output to raw code, (code=0–4095) → void
+                                                                    // maps directly to DAC register; 2048 ≈ 50% of VDD
+        dac.setVoltageEeprom(0.75)                                  // set output and persist to EEPROM, (fraction=0.0–1.0) → void
+                                                                    // DAC register and EEPROM are both written; output survives power cycle
+        dac.setRawEeprom(3072)                                      // set raw code and persist to EEPROM, (code=0–4095) → void
+                                                                    // issues a Write DAC + EEPROM command; takes up to 50 ms
+
+        Thread.sleep(50)                                            // wait for EEPROM write to complete, (ms) → void
+
+        def state = dac.read()                                      // read device state, () → ReadResult
+                                                                    // returns DAC register, EEPROM contents, power-down mode, and RDY/BSY flag
+        printf("code=%d fraction=%.4f pd=%d eepromCode=%d eepromPd=%d ready=%b%n",
+               state.code, state.voltageFraction, state.powerDown,
+               state.eepromCode, state.eepromPowerDown, state.eepromReady)
+
+        dac.setPowerDown(1)                                         // enter power-down mode, (mode=0–3) → void
+                                                                    // 1 = 1 kΩ pull-down to GND; output pin goes high-Z
+        Thread.sleep(100)
+
+        dac.wakeUp()                                                // send General Call Wake-Up to all MCP47xx on bus, () → void
+                                                                    // clears power-down bits in the DAC register; output resumes
+        dac.reset()                                                 // send General Call Reset to all MCP47xx on bus, () → void
+                                                                    // triggers internal POR; reloads EEPROM into DAC register
+
+        def ready = dac.isEepromReady()                            // read RDY/BSY bit, () → boolean
+                                                                    // true when no EEPROM write is in progress
+        println("EEPROM ready: $ready")
+
+    } finally {
+        transport.close()
+        gcTransport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}

--- a/jvm/examples/groovy/adc_dac/mcp4725/Demo.groovy
+++ b/jvm/examples/groovy/adc_dac/mcp4725/Demo.groovy
@@ -1,0 +1,57 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.adc_dac.Mcp4725Full
+
+/**
+ * Triangle wave: ramp the DAC from 0 to full scale and back in 1/20 steps,
+ * printing the fraction and approximate voltage at each step (assumes 3.3 V supply).
+ * Makes a visible sawtooth on an oscilloscope and demonstrates 12-bit resolution.
+ */
+
+final VDD     = 3.3
+final STEPS   = 20
+final STEP_MS = 100
+
+def pi4j = Pi4J.newAutoContext()                              // initialise Pi4J, () → Context
+try {
+    def transport = new I2CTransport(pi4j, 1, 0x60)          // open I²C bus 1, device 0x60, (bus, address) → I2CTransport
+    try {
+        def dac = new Mcp4725Full(transport, null)            // construct driver (no general call needed for this demo), (transport, generalCall) → Mcp4725Full
+
+        // --- Ramp up from 0 V to VDD ---
+        // Each step covers 1/20 of full scale (~165 mV on a 3.3 V rail).
+        // 100 ms per step gives a 2-second rise time — slow enough to observe
+        // on a multimeter and fast enough to show a clean ramp on an oscilloscope.
+        (0..STEPS).each { i ->
+            double fraction = i / STEPS
+            dac.setVoltage(fraction)                          // set output level, (fraction=0.0–1.0) → void
+            printf("↑ fraction=%.2f  V≈%.3f V%n", fraction, fraction * VDD)
+            Thread.sleep(STEP_MS)
+        }
+
+        // --- Ramp down from VDD back to 0 V ---
+        // Descending half of the triangle wave.
+        ((STEPS - 1)..0).each { i ->
+            double fraction = i / STEPS
+            dac.setVoltage(fraction)                          // set output level, (fraction=0.0–1.0) → void
+            printf("↓ fraction=%.2f  V≈%.3f V%n", fraction, fraction * VDD)
+            Thread.sleep(STEP_MS)
+        }
+
+        // --- Return output to 0 V before exit ---
+        // Avoids leaving the rail at an arbitrary level when the process ends.
+        dac.setRaw(0)                                         // set output to 0 V, (code=0–4095) → void
+
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}

--- a/jvm/examples/groovy/adc_dac/mcp4725/Minimal.groovy
+++ b/jvm/examples/groovy/adc_dac/mcp4725/Minimal.groovy
@@ -1,0 +1,31 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.adc_dac.Mcp4725Minimal
+
+def pi4j = Pi4J.newAutoContext()                                // initialise Pi4J, () → Context
+try {
+    def transport = new I2CTransport(pi4j, 1, 0x60)            // open I²C bus 1, device 0x60, (bus, address) → I2CTransport
+    try {
+        def dac = new Mcp4725Minimal(transport)                 // construct driver, (transport) → Mcp4725Minimal
+
+        while (true) {
+            dac.setVoltage(0.0)   // set output to 0 V, (fraction=0.0–1.0) → void
+            Thread.sleep(1000)
+            dac.setVoltage(0.5)   // set output to 50% of VDD, (fraction=0.0–1.0) → void
+            Thread.sleep(1000)
+            dac.setVoltage(1.0)   // set output to VDD, (fraction=0.0–1.0) → void
+            Thread.sleep(1000)
+        }
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}

--- a/jvm/examples/groovy/power/ina219/Complete.groovy
+++ b/jvm/examples/groovy/power/ina219/Complete.groovy
@@ -1,0 +1,75 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina219Full
+
+def pi4j = Pi4J.newAutoContext()                                   // initialise Pi4J, () → Context
+try {
+    def transport = new I2CTransport(pi4j, 1, 0x40)               // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+    try {
+        def ina = new Ina219Full(transport, 0.1, 2.0)              // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina219Full
+
+        ina.configure(                                             // write configuration register, (brng, pga, badc, sadc, mode) → void
+            Ina219Full.BRNG_32V,                                   // bus range 32 V full-scale
+            Ina219Full.PGA_8,                                      // PGA /8: ±320 mV shunt range
+            Ina219Full.ADC_12BIT,                                  // bus ADC 12-bit single sample
+            Ina219Full.ADC_12BIT,                                  // shunt ADC 12-bit single sample
+            Ina219Full.MODE_SHUNT_BUS_CONT)                        // continuous shunt+bus measurement
+                                                                   // packs all fields into config reg 0x00 and writes it atomically
+
+        double v  = ina.voltage()                                  // read bus voltage, () → double V
+                                                                   // right-shifts raw register by 3, multiplies by 4 mV LSB
+        double vs = ina.shuntVoltage()                            // read shunt voltage, () → double V
+                                                                   // interprets raw register as signed 16-bit, multiplies by 10 µV LSB
+        double i  = ina.current()                                 // read current, () → double A
+                                                                   // interprets raw register as signed 16-bit, multiplies by Current_LSB
+        double p  = ina.power()                                   // read power, () → double W
+                                                                   // interprets raw register as unsigned 16-bit, multiplies by Power_LSB (= 20 × Current_LSB)
+        printf("V_bus=%.3f V  V_shunt=%.6f V  I=%.4f A  P=%.4f W%n", v, vs, i, p)
+
+        boolean ready = ina.conversionReady()                     // read conversion-ready flag, () → boolean
+                                                                   // tests CNVR bit (bit 1) of Bus Voltage register; set when new result available
+        boolean ovf   = ina.overflow()                            // read math overflow flag, () → boolean
+                                                                   // tests OVF bit (bit 0) of Bus Voltage register; set on current/power overflow
+        println("conversionReady=${ready}  overflow=${ovf}")
+
+        // Switch to one-shot triggered mode with 128-sample averaging
+        ina.configure(                                             // write configuration register, (brng, pga, badc, sadc, mode) → void
+            Ina219Full.BRNG_32V,
+            Ina219Full.PGA_8,
+            Ina219Full.ADC_AVG_128,                                // 128-sample average, 68 ms conversion
+            Ina219Full.ADC_AVG_128,
+            Ina219Full.MODE_SHUNT_BUS_TRIG)                        // single-shot triggered
+
+        ina.trigger()                                              // trigger a one-shot conversion, () → void
+                                                                   // re-writes the cached config register; starts a new conversion in triggered mode
+        Thread.sleep(150)                                         // wait for 128-sample conversion (~68 ms × 2 channels + margin)
+
+        printf("triggered V=%.3f V  I=%.4f A%n", ina.voltage(), ina.current())
+
+        ina.shutdown()                                             // enter power-down mode, () → void
+                                                                   // writes config reg with MODE=000 (power-down); ADC powered off
+        Thread.sleep(10)
+
+        ina.wake()                                                 // exit power-down, restore configuration, () → void
+                                                                   // re-writes the full cached config register including original MODE bits
+        Thread.sleep(10)
+
+        ina.reset()                                                // software reset and restore config+calibration, () → void
+                                                                   // sets RST bit (bit 15), then re-writes config and recomputes CAL register
+        Thread.sleep(10)
+
+        printf("after reset V=%.3f V%n", ina.voltage())
+
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}

--- a/jvm/examples/groovy/power/ina219/Demo.groovy
+++ b/jvm/examples/groovy/power/ina219/Demo.groovy
@@ -1,0 +1,81 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import groovy.transform.Field
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina219Full
+
+/**
+ * Power-supply sanity check: poll the INA219 once per second for 10 seconds,
+ * printing bus voltage, current, and power. A prompt between samples 4 and 5
+ * lets the user switch on the load mid-run. After the run, min/max/mean of
+ * each measured quantity are reported.
+ */
+
+@Field final int  SAMPLES   = 10
+@Field final long PERIOD_MS = 1000L
+
+def pi4j = Pi4J.newAutoContext()                                   // initialise Pi4J, () → Context
+try {
+    def transport = new I2CTransport(pi4j, 1, 0x40)               // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+    try {
+        def ina = new Ina219Full(transport, 0.1, 2.0)              // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina219Full
+
+        // --- Configure for noise-sensitive power rail monitoring ---
+        // 128-sample averaging suppresses switching noise on a noisy 5 V rail;
+        // continuous mode avoids re-triggering overhead between measurements.
+        ina.configure(Ina219Full.BRNG_32V, Ina219Full.PGA_8,
+                      Ina219Full.ADC_AVG_128, Ina219Full.ADC_AVG_128,
+                      Ina219Full.MODE_SHUNT_BUS_CONT)              // configure ADC, (brng, pga, badc, sadc, mode) → void
+
+        double[] voltages = new double[SAMPLES]
+        double[] currents = new double[SAMPLES]
+        double[] powers   = new double[SAMPLES]
+
+        println("=== INA219 power-supply sanity check ===")
+        printf("%-4s  %-10s  %-10s  %-10s%n", "#", "V_bus (V)", "I (A)", "P (W)")
+
+        // --- Collect 10 one-second samples ---
+        // Samples 1–4 are taken with the load in its initial state.
+        // After sample 4 the user is prompted to switch the load on,
+        // making the current step visible in the data.
+        (0 until SAMPLES).each { int n ->
+            if (n == 4) {
+                println("Switch on load now...")
+            }
+
+            double v = ina.voltage()   // read bus voltage, () → double V
+            double i = ina.current()   // read current, () → double A
+            double p = ina.power()     // read power, () → double W
+
+            voltages[n] = v
+            currents[n] = i
+            powers[n]   = p
+
+            printf("%-4d  %-10.3f  %-10.4f  %-10.4f%n", n + 1, v, i, p)
+            Thread.sleep(PERIOD_MS)
+        }
+
+        // --- Compute and print summary statistics ---
+        // Min/max/mean give a quick overview of load stability and
+        // reveal any voltage sag under load.
+        println("\n=== Summary ===")
+        printf("%-12s  %-10s  %-10s  %-10s%n", "", "V_bus (V)", "I (A)", "P (W)")
+        printf("%-12s  %-10.3f  %-10.4f  %-10.4f%n",
+               "min", voltages.min(), currents.min(), powers.min())
+        printf("%-12s  %-10.3f  %-10.4f  %-10.4f%n",
+               "max", voltages.max(), currents.max(), powers.max())
+        printf("%-12s  %-10.3f  %-10.4f  %-10.4f%n",
+               "mean", voltages.sum() / SAMPLES, currents.sum() / SAMPLES, powers.sum() / SAMPLES)
+
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}

--- a/jvm/examples/groovy/power/ina219/Minimal.groovy
+++ b/jvm/examples/groovy/power/ina219/Minimal.groovy
@@ -1,0 +1,31 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina219Minimal
+
+def pi4j = Pi4J.newAutoContext()                                  // initialise Pi4J, () → Context
+try {
+    def transport = new I2CTransport(pi4j, 1, 0x40)              // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+    try {
+        def ina = new Ina219Minimal(transport)                    // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina219Minimal
+
+        while (true) {
+            double v  = ina.voltage()       // read bus voltage, () → double V
+            double vs = ina.shuntVoltage()  // read shunt voltage, () → double V
+            double i  = ina.current()       // read current, () → double A
+            double p  = ina.power()         // read power, () → double W
+            printf("V_bus=%.3f V  V_shunt=%.6f V  I=%.4f A  P=%.4f W%n", v, vs, i, p)
+            Thread.sleep(1000)
+        }
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}

--- a/jvm/examples/groovy/power/ina226/Complete.groovy
+++ b/jvm/examples/groovy/power/ina226/Complete.groovy
@@ -1,0 +1,69 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina226Full
+
+def pi4j = Pi4J.newAutoContext()                                    // initialise Pi4J, () → Context
+try {
+    def transport = new I2CTransport(pi4j, 1, 0x40)                // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+    try {
+        def ina = new Ina226Full(transport, 0.1d, 2.0d)            // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina226Full
+
+        double v  = ina.voltage()                                   // read bus voltage, () → double V
+                                                                    // unsigned 16-bit, 1.25 mV per LSB
+        double vs = ina.shuntVoltage()                              // read shunt voltage, () → double V
+                                                                    // signed 16-bit, 2.5 µV per LSB
+        double c  = ina.current()                                   // read current, () → double A
+                                                                    // signed, Current_LSB = maxCurrent / 32768 per bit
+        double p  = ina.power()                                     // read power, () → double W
+                                                                    // unsigned, power = 25 × Current_LSB × raw
+        printf("V=%.3f V  Vshunt=%.6f V  I=%.4f A  P=%.4f W%n", v, vs, c, p)
+
+        ina.configure(Ina226Full.AVG_128, Ina226Full.CT_1100US,    // configure ADC, (avg=4, vbusCt=4, vshCt=4, mode=7) → void
+                      Ina226Full.CT_1100US, Ina226Full.MODE_SHUNT_BUS_CONT)
+                                                                    // sets 128-sample averaging and 1.1 ms conversion times; continuous mode
+
+        boolean ready = ina.conversionReady()                       // check conversion ready flag, () → boolean
+                                                                    // reads CVRF bit (bit 3) from Mask/Enable register
+        println("Conversion ready: $ready")
+
+        boolean ovf = ina.overflow()                                // check math overflow flag, () → boolean
+                                                                    // reads OVF bit (bit 2) from Mask/Enable register
+        println("Overflow: $ovf")
+
+        ina.setAlert(Ina226Full.POL, 1.0d)                         // set power over-limit alert to 1 W, (function=POL, limit=1.0 W) → void
+                                                                    // writes function to Mask/Enable, limit raw = int(1.0 / (25 × Current_LSB)) to Alert Limit
+
+        int flags = ina.alertFlags()                                // read alert flags, () → int
+                                                                    // reads Mask/Enable register; reading also clears the alert latch
+        printf("Alert flags: 0x%04X%n", flags)
+
+        int mfrId = ina.manufacturerId()                            // read manufacturer ID, () → int
+                                                                    // should return 0x5449 ("TI")
+        int dieId = ina.dieId()                                     // read die ID, () → int
+                                                                    // should return 0x2260 for INA226
+        printf("Manufacturer ID: 0x%04X  Die ID: 0x%04X%n", mfrId, dieId)
+
+        ina.shutdown()                                              // enter power-down mode, () → void
+                                                                    // sets MODE=000; previously active mode stored for wake()
+        Thread.sleep(100)
+
+        ina.wake()                                                  // restore previous operating mode, () → void
+                                                                    // writes previously stored mode bits back to Configuration register
+        Thread.sleep(10)
+
+        ina.reset()                                                 // reset chip and re-write calibration, () → void
+                                                                    // sets RST bit; chip returns to 0x4127; calibration re-written
+
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}

--- a/jvm/examples/groovy/power/ina226/Demo.groovy
+++ b/jvm/examples/groovy/power/ina226/Demo.groovy
@@ -1,0 +1,79 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina226Full
+
+/**
+ * Power-supply monitoring demo: poll voltage, current, and power once per second
+ * for 10 seconds, track min/max/mean, and demonstrate a power over-limit alert.
+ *
+ * Between samples 4 and 5 the user is prompted to switch on a load so that the
+ * effect of load variation is visible in the statistics. The power over-limit
+ * alert is set to 1 W; alertFlags() is checked on every iteration.
+ */
+
+final SAMPLES     = 10
+final INTERVAL_MS = 1000
+final ALERT_POWER = 1.0d  // W
+
+def pi4j = Pi4J.newAutoContext()                                    // initialise Pi4J, () → Context
+try {
+    def transport = new I2CTransport(pi4j, 1, 0x40)                // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+    try {
+        def ina = new Ina226Full(transport, 0.1d, 2.0d)            // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina226Full
+
+        // --- Configure for noise-sensitive power rail monitoring ---
+        // 128-sample averaging suppresses switching noise on a noisy supply;
+        // continuous mode avoids re-triggering overhead between measurements.
+        ina.configure(Ina226Full.AVG_128, Ina226Full.CT_1100US,    // configure ADC, (avg=4, vbusCt=4, vshCt=4, mode=7) → void
+                      Ina226Full.CT_1100US, Ina226Full.MODE_SHUNT_BUS_CONT)
+
+        // --- Arm a power over-limit alert at 1 W ---
+        // The POL function asserts the ALERT pin and sets the OVF latch when
+        // the calculated power register exceeds the threshold. We poll alertFlags()
+        // on each iteration instead of wiring a GPIO interrupt.
+        ina.setAlert(Ina226Full.POL, ALERT_POWER)                   // set power over-limit alert, (function=POL, limit=1.0 W) → void
+
+        double minV = Double.MAX_VALUE, maxV = -Double.MAX_VALUE, sumV = 0.0d
+        double minI = Double.MAX_VALUE, maxI = -Double.MAX_VALUE, sumI = 0.0d
+        double minP = Double.MAX_VALUE, maxP = -Double.MAX_VALUE, sumP = 0.0d
+
+        (0..<SAMPLES).each { i ->
+            if (i == 4) println('Switch on load now...')
+
+            double v = ina.voltage()      // read bus voltage, () → double V
+            double c = ina.current()      // read current, () → double A
+            double p = ina.power()        // read power, () → double W
+
+            int alertRaw = ina.alertFlags()  // read alert flags (clears latch), () → int
+            boolean alert = (alertRaw & Ina226Full.POL) != 0
+            printf("Sample %2d: V=%.3f V  I=%.4f A  P=%.4f W%s%n",
+                   i + 1, v, c, p, alert ? '  [ALERT: power over limit]' : '')
+
+            if (v < minV) minV = v; if (v > maxV) maxV = v; sumV += v
+            if (c < minI) minI = c; if (c > maxI) maxI = c; sumI += c
+            if (p < minP) minP = p; if (p > maxP) maxP = p; sumP += p
+
+            Thread.sleep(INTERVAL_MS)
+        }
+
+        // --- Print summary statistics ---
+        // Min/max/mean over the 10-second window gives a compact view of
+        // supply stability and load variation.
+        println()
+        printf("Bus voltage  — min=%.3f V   max=%.3f V   mean=%.3f V%n", minV, maxV, sumV / SAMPLES)
+        printf("Current      — min=%.4f A  max=%.4f A  mean=%.4f A%n",   minI, maxI, sumI / SAMPLES)
+        printf("Power        — min=%.4f W  max=%.4f W  mean=%.4f W%n",   minP, maxP, sumP / SAMPLES)
+
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}

--- a/jvm/examples/groovy/power/ina226/Minimal.groovy
+++ b/jvm/examples/groovy/power/ina226/Minimal.groovy
@@ -1,0 +1,31 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina226Minimal
+
+def pi4j = Pi4J.newAutoContext()                                   // initialise Pi4J, () → Context
+try {
+    def transport = new I2CTransport(pi4j, 1, 0x40)               // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+    try {
+        def ina = new Ina226Minimal(transport, 0.1d, 2.0d)        // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina226Minimal
+
+        10.times {
+            double v  = ina.voltage()       // read bus voltage, () → double V
+            double vs = ina.shuntVoltage()  // read shunt voltage, () → double V
+            double c  = ina.current()       // read current, () → double A
+            double p  = ina.power()         // read power, () → double W
+            printf("V=%.3f V  Vshunt=%.6f V  I=%.4f A  P=%.4f W%n", v, vs, c, p)
+            Thread.sleep(1000)
+        }
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}

--- a/jvm/examples/groovy/power/ina3221/Complete.groovy
+++ b/jvm/examples/groovy/power/ina3221/Complete.groovy
@@ -1,0 +1,92 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina3221Full
+
+def pi4j = Pi4J.newAutoContext()                                            // initialise Pi4J, () → Context
+try {
+    def transport = new I2CTransport(pi4j, 1, 0x40)                        // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+    try {
+        def ina = new Ina3221Full(transport)                                // construct driver (0.1 Ω shunt all channels), (transport) → Ina3221Full
+
+        ina.configure(1, 4, 4, Ina3221Full.MODE_SHUNT_BUS_CONT)            // configure averaging and conversion times, (avg=0–7, vbusCt=0–7, vshCt=0–7, mode=0–7) → void
+                                                                            // avg=1 means 4-sample average; vbusCt/vshCt=4 means 1.1 ms each
+
+        (1..3).each { ch ->
+            ina.enableChannel(ch, true)                                     // enable a channel, (channel=1–3, enabled) → void
+                                                                            // sets the CH<n>en bit in the configuration register
+            def en = ina.channelEnabled(ch)                                 // read channel enable state, (channel=1–3) → boolean
+                                                                            // true when the CH<n>en bit is set
+            println("CH${ch} enabled: ${en}")
+        }
+
+        (1..3).each { ch ->
+            def v  = ina.voltage(ch)                                        // read bus voltage, (channel=1–3) → double V
+                                                                            // left-aligned 12-bit unsigned, 8 mV LSB
+            def sv = ina.shuntVoltage(ch)                                   // read shunt voltage, (channel=1–3) → double V
+                                                                            // left-aligned 13-bit signed, 40 µV LSB
+            def i  = ina.current(ch)                                        // compute current from shunt voltage, (channel=1–3) → double A
+                                                                            // current = shuntVoltage / rShunt
+            def p  = ina.power(ch)                                          // compute power, (channel=1–3) → double W
+                                                                            // power = busVoltage × current
+            printf("CH%d: %.3f V  %.6f V_shunt  %.4f A  %.4f W%n", ch, v, sv, i, p)
+        }
+
+        def cvrf = ina.conversionReady()                                    // read conversion-ready flag, () → boolean
+                                                                            // CVRF bit (bit 0) of Mask/Enable; set after each full conversion
+        println("Conversion ready: ${cvrf}")
+
+        ina.setCriticalAlert(1, 0.05)                                       // set critical alert on channel 1, (channel=1–3, limitV) → void
+                                                                            // alert fires when |shunt voltage| exceeds this threshold
+        ina.setWarningAlert(1, 0.04)                                        // set warning alert on channel 1, (channel=1–3, limitV) → void
+                                                                            // alert fires when |shunt voltage| exceeds this threshold
+        ina.setCriticalAlert(2, 0.05)                                       // set critical alert on channel 2, (channel=1–3, limitV) → void
+        ina.setWarningAlert(2, 0.04)                                        // set warning alert on channel 2, (channel=1–3, limitV) → void
+        ina.setCriticalAlert(3, 0.05)                                       // set critical alert on channel 3, (channel=1–3, limitV) → void
+        ina.setWarningAlert(3, 0.04)                                        // set warning alert on channel 3, (channel=1–3, limitV) → void
+
+        ina.setPowerValidLimits(5.5, 4.5)                                   // set power-valid thresholds, (upperV, lowerV) → void
+                                                                            // PVF bit set when all enabled bus voltages are within [lowerV, upperV]
+        def pv = ina.powerValid()                                           // read power-valid flag, () → boolean
+                                                                            // PVF bit (bit 2) of Mask/Enable register
+        println("Power valid: ${pv}")
+
+        ina.setSummationChannels([1, 2, 3] as int[], 0.1)                   // enable summation for all channels with limit, (channels, limitV) → void
+                                                                            // sets SCC bits in Mask/Enable and writes the sum limit register
+        def sumV = ina.summationValue()                                     // read shunt-voltage sum, () → double V
+                                                                            // 14-bit signed, left-aligned by 1; LSB = 20 µV
+        printf("Shunt voltage sum: %.6f V%n", sumV)
+
+        def flags = ina.alertFlags()                                        // read and clear alert flags, () → int
+                                                                            // reads Mask/Enable; clears latched flags; inspect against CF1/WF1/PVF etc.
+        printf("Alert flags: 0x%04X%n", flags)
+
+        def mfr = ina.manufacturerId()                                      // read manufacturer ID, () → int
+                                                                            // expected 0x5449 ("TI")
+        def die = ina.dieId()                                               // read die ID, () → int
+                                                                            // expected 0x3220
+        printf("Manufacturer ID: 0x%04X  Die ID: 0x%04X%n", mfr, die)
+
+        ina.shutdown()                                                       // enter power-down mode (MODE=000), () → void
+                                                                            // saves current MODE so wake() can restore it
+        Thread.sleep(100)
+
+        ina.wake()                                                           // restore saved operating mode, () → void
+                                                                            // writes previously saved MODE bits back into config register
+        Thread.sleep(100)
+
+        ina.reset()                                                          // software reset via RST bit, then restore saved mode, () → void
+                                                                            // resets all registers to hardware defaults, then writes saved MODE back
+
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}

--- a/jvm/examples/groovy/power/ina3221/Demo.groovy
+++ b/jvm/examples/groovy/power/ina3221/Demo.groovy
@@ -1,0 +1,115 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina3221Full
+
+/**
+ * Three-rail power monitor demo.
+ *
+ * Wire the INA3221 across three power rails (e.g. 3.3 V, 5 V, 12 V) each with
+ * a 0.1 Ω shunt. The script polls all three channels once per second for 30 s,
+ * printing a tabular row per second. At t=10 s it arms critical alerts at 1.5×
+ * the observed current draw on each channel. At t=20 s it enables summation
+ * across all three channels. After the run it dumps the final alert flags.
+ */
+
+final POLL_S    = 30
+final R_SHUNT   = 0.1   // Ω
+final ALERT_MUL = 1.5
+
+def pi4j = Pi4J.newAutoContext()                                // initialise Pi4J, () → Context
+try {
+    def transport = new I2CTransport(pi4j, 1, 0x40)            // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+    try {
+
+        // --- Construct driver with 0.1 Ω shunt on all rails ---
+        // Using a common shunt value simplifies wiring; per-channel values can
+        // be supplied via the double[] constructor if rails differ.
+        def ina = new Ina3221Full(transport, R_SHUNT)           // construct driver, (transport, rShunt=0.1 Ω) → Ina3221Full
+
+        // --- Configure: 4-sample averaging, 1.1 ms conversions, continuous mode ---
+        // 4-sample averaging reduces noise on switching-mode supplies without
+        // significantly increasing the effective sample interval (~10 ms total).
+        ina.configure(1, 4, 4, Ina3221Full.MODE_SHUNT_BUS_CONT) // configure ADC, (avg=1→4 samples, vbusCt=4, vshCt=4, mode=7) → void
+
+        def firstI = [0.0d, 0.0d, 0.0d]
+        boolean alertsArmed = false
+        boolean summationEnabled = false
+
+        printf("%-5s  %-24s  %-24s  %-24s%n",
+               't(s)', '--- CH1 V/A/W ---', '--- CH2 V/A/W ---', '--- CH3 V/A/W ---')
+        println('-' * 85)
+
+        (0..<POLL_S).each { t ->
+
+            // --- Poll all three channels ---
+            // Each read is two I²C transactions (bus + shunt register). Current
+            // and power are derived in software — no hardware division needed.
+            def v = [0d, 0d, 0d, 0d]
+            def i = [0d, 0d, 0d, 0d]
+            def p = [0d, 0d, 0d, 0d]
+            (1..3).each { ch ->
+                v[ch] = ina.voltage(ch)                         // read bus voltage, (channel=1–3) → double V
+                i[ch] = ina.current(ch)                         // compute current, (channel=1–3) → double A
+                p[ch] = ina.power(ch)                           // compute power, (channel=1–3) → double W
+            }
+
+            if (t == 0) {
+                (1..3).each { ch -> firstI[ch - 1] = i[ch] }
+            }
+
+            printf("%-5d  %6.3f V %6.3f A %6.3f W  %6.3f V %6.3f A %6.3f W  %6.3f V %6.3f A %6.3f W%n",
+                   t,
+                   v[1], i[1], p[1],
+                   v[2], i[2], p[2],
+                   v[3], i[3], p[3])
+
+            // --- At t=10 s: arm critical alerts at 1.5× initial draw ---
+            // Setting the limit as a shunt voltage: limit_V = current × rShunt × 1.5.
+            // This lets the hardware flag transient spikes without software polling.
+            if (t == 10 && !alertsArmed) {
+                (1..3).each { ch ->
+                    double limit = Math.abs(firstI[ch - 1]) * R_SHUNT * ALERT_MUL
+                    if (limit < 40e-6) limit = 40e-6
+                    ina.setCriticalAlert(ch, limit)             // set critical alert, (channel=1–3, limitV) → void
+                }
+                println('  [t=10] Critical alerts armed at 1.5x initial draw')
+                alertsArmed = true
+            }
+
+            // --- At t=20 s: enable summation across all three channels ---
+            // Summation lets the hardware accumulate shunt voltages; the sum
+            // register gives total power-bus current in a single read.
+            if (t == 20 && !summationEnabled) {
+                double sumLimit = (Math.abs(firstI[0]) + Math.abs(firstI[1]) + Math.abs(firstI[2])) *
+                                   R_SHUNT * ALERT_MUL
+                if (sumLimit < 40e-6) sumLimit = 40e-6
+                ina.setSummationChannels([1, 2, 3] as int[], sumLimit) // enable all-channel summation, (channels, limitV) → void
+                println('  [t=20] Summation enabled for channels 1+2+3')
+                summationEnabled = true
+            }
+
+            Thread.sleep(1000)
+        }
+
+        // --- Final alert flag dump ---
+        // Reading Mask/Enable clears latched flags; inspect individual bits.
+        def flags = ina.alertFlags()                            // read and clear alert flags, () → int
+        printf("%nFinal alert flags: 0x%04X%n", flags)
+        if (flags & Ina3221Full.CF1) println('  Critical alert fired on CH1')
+        if (flags & Ina3221Full.CF2) println('  Critical alert fired on CH2')
+        if (flags & Ina3221Full.CF3) println('  Critical alert fired on CH3')
+        if (flags & Ina3221Full.SF)  println('  Summation alert fired')
+
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}

--- a/jvm/examples/groovy/power/ina3221/Minimal.groovy
+++ b/jvm/examples/groovy/power/ina3221/Minimal.groovy
@@ -1,0 +1,33 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina3221Minimal
+
+def pi4j = Pi4J.newAutoContext()                                // initialise Pi4J, () → Context
+try {
+    def transport = new I2CTransport(pi4j, 1, 0x40)            // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+    try {
+        def ina = new Ina3221Minimal(transport)                 // construct driver (0.1 Ω shunt all channels), (transport) → Ina3221Minimal
+
+        while (true) {
+            (1..3).each { ch ->
+                def v = ina.voltage(ch)                         // read bus voltage, (channel=1–3) → double V
+                def i = ina.current(ch)                         // compute current via shunt, (channel=1–3) → double A
+                def p = ina.power(ch)                           // compute power, (channel=1–3) → double W
+                printf("CH%d: %.3f V  %.4f A  %.4f W%n", ch, v, i, p)
+            }
+            println('---')
+            Thread.sleep(1000)
+        }
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}

--- a/jvm/examples/groovy/pressure/bmp180/Complete.groovy
+++ b/jvm/examples/groovy/pressure/bmp180/Complete.groovy
@@ -1,0 +1,62 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.pressure.Bmp180Full
+
+def pi4j = Pi4J.newAutoContext()                                    // initialise Pi4J, () → Context
+try {
+    def transport = new I2CTransport(pi4j, 1, 0x77)                // open I²C bus 1, device 0x77, (bus, address=0x77) → I2CTransport
+    try {
+        def sensor = new Bmp180Full(transport)                      // construct driver, verifies chip ID and loads calibration, (transport) → Bmp180Full
+
+        int id = sensor.chipId()                                    // read chip ID register 0xD0, () → int
+                                                                    // returns 0x55 for BMP180; useful for confirming the device is present
+        printf("chip ID: 0x%02X%n", id)
+
+        int oss = sensor.oversampling()                             // read current OSS setting, () → int
+                                                                    // 0 = ultra-low-power (default), 1 = standard, 2 = high-res, 3 = ultra-high-res
+        println("oversampling: ${oss}")
+
+        sensor.setOversampling(Bmp180Full.OSS_HIGH_RES)            // set oversampling to high-resolution mode, (oss=0–3) → void
+                                                                    // OSS = 2: 4 internal samples averaged, ~13.5 ms conversion time
+
+        double t = sensor.temperature()                             // read temperature, () → double °C
+                                                                    // triggers a 5 ms ADC conversion, applies Bosch integer compensation
+        printf("temperature: %.2f °C%n", t)
+
+        double p = sensor.pressure()                                // read pressure, () → double hPa
+                                                                    // re-reads temperature to refresh B5, then triggers pressure ADC
+        printf("pressure: %.2f hPa%n", p)
+
+        double alt = sensor.altitude()                              // compute altitude using default sea-level pressure 1013.25 hPa, () → double m
+                                                                    // applies barometric formula: 44330 × (1 − (p/1013.25)^(1/5.255))
+        printf("altitude: %.1f m%n", alt)
+
+        double altRef = sensor.altitude(1013.00)                   // compute altitude with custom sea-level pressure, (seaLevelHpa=1013.25 hPa) → double m
+                                                                    // use local QNH for accurate terrain altitude
+        printf("altitude (QNH 1013.00): %.1f m%n", altRef)
+
+        double slp = sensor.seaLevelPressure(50.0)                 // back-calculate sea-level pressure at known altitude, (altitudeM=0.0 m) → double hPa
+                                                                    // reduces station pressure to MSL using the barometric formula inverse
+        printf("sea-level pressure at 50 m: %.2f hPa%n", slp)
+
+        sensor.reset()                                              // soft-reset the chip and reload calibration, () → void
+                                                                    // writes 0xB6 to 0xE0, waits 15 ms, then re-reads calibration EEPROM
+
+        sensor.setOversampling(Bmp180Full.OSS_ULP)                 // restore ultra-low-power mode, (oss=0–3) → void
+                                                                    // OSS = 0: single sample, ~4.5 ms, lowest power consumption
+
+        println("oversampling after reset: ${sensor.oversampling()}") // read current OSS setting, () → int
+                                                                       // reset() restores chip but local field retains 0 since it was set after construction
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}

--- a/jvm/examples/groovy/pressure/bmp180/Demo.groovy
+++ b/jvm/examples/groovy/pressure/bmp180/Demo.groovy
@@ -1,0 +1,87 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.pressure.Bmp180Full
+
+/**
+ * Pocket altimeter: 60-second run at 1 Hz in ULP mode.
+ *
+ * The first reading establishes the sea-level reference so altitude starts at 0.
+ * Each subsequent reading reports temperature, pressure, altitude, and vertical
+ * displacement (in cm) relative to the reference. After the run, prints
+ * min/max/mean for all three quantities.
+ */
+
+final SAMPLES     = 60
+final INTERVAL_MS = 1000L
+
+def pi4j = Pi4J.newAutoContext()                               // initialise Pi4J, () → Context
+try {
+    def transport = new I2CTransport(pi4j, 1, 0x77)           // open I²C bus 1, device 0x77 (fixed address), (bus, address=0x77) → I2CTransport
+    try {
+        def sensor = new Bmp180Full(transport)                 // construct driver, verifies chip ID, reads calibration, (transport) → Bmp180Full
+
+        // --- Configure for low-power continuous monitoring ---
+        // ULP mode (OSS = 0) minimises power draw (~3 µA RMS) and conversion time
+        // (~4.5 ms). For a pocket altimeter taking one sample per second the
+        // extra resolution of higher OSS is not needed; ULP resolves ~1 m.
+        sensor.setOversampling(Bmp180Full.OSS_ULP)             // set ultra-low-power mode, (oss=0–3) → void
+
+        // --- Take first reading to establish reference altitude ---
+        // The sea-level pressure derived from this reading anchors altitude = 0.
+        // Any subsequent change in pressure will appear as vertical displacement.
+        double firstPressure = sensor.pressure()               // read pressure for reference, () → double hPa
+        double seaLevel      = sensor.seaLevelPressure(0.0)   // derive sea-level pressure at altitude = 0, (altitudeM=0.0 m) → double hPa
+        double firstTemp     = sensor.temperature()            // read temperature for reference, () → double °C
+        double firstAlt      = sensor.altitude(seaLevel)      // compute altitude (should be ~0), (seaLevelHpa) → double m
+
+        printf("Reference: temperature=%.2f °C  pressure=%.2f hPa  altitude=%.1f m  (sea-level ref=%.2f hPa)%n",
+               firstTemp, firstPressure, firstAlt, seaLevel)
+
+        double[] temps     = new double[SAMPLES]
+        double[] pressures = new double[SAMPLES]
+        double[] altitudes = new double[SAMPLES]
+
+        // --- 60-second sampling loop ---
+        // Each iteration reads temperature, pressure, and altitude; prints the
+        // current values plus vertical displacement from the reference position.
+        (0..<SAMPLES).each { int i ->
+            double t   = sensor.temperature()                  // read temperature, () → double °C
+            double p   = sensor.pressure()                     // read pressure, () → double hPa
+            double alt = sensor.altitude(seaLevel)             // compute altitude relative to reference, (seaLevelHpa) → double m
+            double dAlt = alt - firstAlt
+
+            temps[i]     = t
+            pressures[i] = p
+            altitudes[i] = alt
+
+            String direction = dAlt > 0.005 ? 'up' : dAlt < -0.005 ? 'down' : 'level'
+            printf("[%2d] temperature=%.2f °C  pressure=%.2f hPa  altitude=%.1f m  moved %s %.0f cm%n",
+                   i + 1, t, p, alt, direction, Math.abs(dAlt) * 100)
+
+            Thread.sleep(INTERVAL_MS)
+        }
+
+        // --- Print summary statistics ---
+        // After the run, report the full range and mean for each quantity so
+        // the user can see how much the environment changed during the session.
+        printf("%n--- Summary (%d samples) ---%n", SAMPLES)
+        printf("Temperature: min=%.2f °C  max=%.2f °C  mean=%.2f °C%n",
+               temps.min(), temps.max(), temps.sum() / SAMPLES)
+        printf("Pressure:    min=%.2f hPa  max=%.2f hPa  mean=%.2f hPa%n",
+               pressures.min(), pressures.max(), pressures.sum() / SAMPLES)
+        printf("Altitude:    min=%.1f m  max=%.1f m  mean=%.1f m%n",
+               altitudes.min(), altitudes.max(), altitudes.sum() / SAMPLES)
+
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}

--- a/jvm/examples/groovy/pressure/bmp180/Minimal.groovy
+++ b/jvm/examples/groovy/pressure/bmp180/Minimal.groovy
@@ -1,0 +1,29 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.pressure.Bmp180Minimal
+
+def pi4j = Pi4J.newAutoContext()                                // initialise Pi4J, () → Context
+try {
+    def transport = new I2CTransport(pi4j, 1, 0x77)            // open I²C bus 1, device 0x77, (bus, address=0x77) → I2CTransport
+    try {
+        def sensor = new Bmp180Minimal(transport)               // construct driver, verifies chip ID and loads calibration, (transport) → Bmp180Minimal
+
+        while (true) {
+            double t = sensor.temperature()                     // read temperature, () → double °C
+            double p = sensor.pressure()                        // read pressure, () → double hPa
+            printf("temperature=%.2f °C  pressure=%.2f hPa%n", t, p)
+            Thread.sleep(1000)
+        }
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}

--- a/jvm/examples/java/adc_dac/mcp4725/Complete.java
+++ b/jvm/examples/java/adc_dac/mcp4725/Complete.java
@@ -1,0 +1,54 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.adc_dac.Mcp4725Full;
+
+public class Complete {
+    public static void main(String[] args) throws Exception {
+        var pi4j = Pi4J.newAutoContext();                               // initialise Pi4J, () → Context
+        try (var transport = new I2CTransport(pi4j, 1, 0x60);         // open device transport, (bus, address) → I2CTransport
+             var gcTransport = new I2CTransport(pi4j, 1, 0x00)) {     // open general call transport, (bus, address=0x00) → I2CTransport
+
+            var dac = new Mcp4725Full(transport, gcTransport);         // construct driver, (transport, generalCall) → Mcp4725Full
+
+            dac.setVoltage(0.5);                                        // set output to 50% of VDD, (fraction=0.0–1.0) → void
+                                                                        // converts fraction to 12-bit code and issues a Fast Write
+            dac.setRaw(2048);                                           // set output to raw code, (code=0–4095) → void
+                                                                        // maps directly to DAC register; 2048 ≈ 50% of VDD
+            dac.setVoltageEeprom(0.75);                                 // set output and persist to EEPROM, (fraction=0.0–1.0) → void
+                                                                        // DAC register and EEPROM are both written; output survives power cycle
+            dac.setRawEeprom(3072);                                     // set raw code and persist to EEPROM, (code=0–4095) → void
+                                                                        // issues a Write DAC + EEPROM command; takes up to 50 ms
+
+            Thread.sleep(50);                                           // wait for EEPROM write to complete, (ms) → void
+
+            var state = dac.read();                                     // read device state, () → ReadResult
+                                                                        // returns DAC register, EEPROM contents, power-down mode, and RDY/BSY flag
+            System.out.printf("code=%d fraction=%.4f pd=%d eepromCode=%d eepromPd=%d ready=%b%n",
+                    state.code(), state.voltageFraction(), state.powerDown(),
+                    state.eepromCode(), state.eepromPowerDown(), state.eepromReady());
+
+            dac.setPowerDown(1);                                        // enter power-down mode, (mode=0–3) → void
+                                                                        // 1 = 1 kΩ pull-down to GND; output pin goes high-Z
+            Thread.sleep(100);
+
+            dac.wakeUp();                                               // send General Call Wake-Up to all MCP47xx on bus, () → void
+                                                                        // clears power-down bits in the DAC register; output resumes
+            dac.reset();                                                // send General Call Reset to all MCP47xx on bus, () → void
+                                                                        // triggers internal POR; reloads EEPROM into DAC register
+
+            boolean ready = dac.isEepromReady();                       // read RDY/BSY bit, () → boolean
+                                                                        // true when no EEPROM write is in progress
+            System.out.println("EEPROM ready: " + ready);
+
+        } finally {
+            pi4j.shutdown();
+        }
+    }
+}

--- a/jvm/examples/java/adc_dac/mcp4725/Demo.java
+++ b/jvm/examples/java/adc_dac/mcp4725/Demo.java
@@ -1,0 +1,56 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.adc_dac.Mcp4725Full;
+
+/**
+ * Triangle wave: ramp the DAC from 0 to full scale and back in 1/20 steps,
+ * printing the fraction and approximate voltage at each step (assumes 3.3 V supply).
+ * Makes a visible sawtooth on an oscilloscope and demonstrates 12-bit resolution.
+ */
+public class Demo {
+
+    private static final double VDD = 3.3;
+    private static final int    STEPS = 20;
+    private static final long   STEP_MS = 100;
+
+    public static void main(String[] args) throws Exception {
+        var pi4j = Pi4J.newAutoContext();                              // initialise Pi4J, () → Context
+        try (var transport = new I2CTransport(pi4j, 1, 0x60)) {      // open I²C bus 1, device 0x60, (bus, address) → I2CTransport
+            var dac = new Mcp4725Full(transport, null);               // construct driver (no general call needed for this demo), (transport, generalCall) → Mcp4725Full
+
+            // --- Ramp up from 0 V to VDD ---
+            // Each step covers 1/20 of full scale (~163 mV on a 3.3 V rail).
+            // 100 ms per step gives a 2-second rise time — slow enough to observe
+            // on a multimeter and fast enough to show a clean ramp on an oscilloscope.
+            for (int i = 0; i <= STEPS; i++) {
+                double fraction = (double) i / STEPS;
+                dac.setVoltage(fraction);                              // set output level, (fraction=0.0–1.0) → void
+                System.out.printf("↑ fraction=%.2f  V≈%.3f V%n", fraction, fraction * VDD);
+                Thread.sleep(STEP_MS);
+            }
+
+            // --- Ramp down from VDD back to 0 V ---
+            // Descending half of the triangle wave.
+            for (int i = STEPS - 1; i >= 0; i--) {
+                double fraction = (double) i / STEPS;
+                dac.setVoltage(fraction);                              // set output level, (fraction=0.0–1.0) → void
+                System.out.printf("↓ fraction=%.2f  V≈%.3f V%n", fraction, fraction * VDD);
+                Thread.sleep(STEP_MS);
+            }
+
+            // --- Return output to 0 V before exit ---
+            // Avoids leaving the rail at an arbitrary level when the process ends.
+            dac.setRaw(0);                                             // set output to 0 V, (code=0–4095) → void
+
+        } finally {
+            pi4j.shutdown();
+        }
+    }
+}

--- a/jvm/examples/java/adc_dac/mcp4725/Minimal.java
+++ b/jvm/examples/java/adc_dac/mcp4725/Minimal.java
@@ -1,0 +1,30 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.adc_dac.Mcp4725Minimal;
+
+public class Minimal {
+    public static void main(String[] args) throws Exception {
+        var pi4j = Pi4J.newAutoContext();                           // initialise Pi4J, () → Context
+        try (var transport = new I2CTransport(pi4j, 1, 0x60)) {   // open I²C bus 1, device 0x60, (bus, address) → I2CTransport
+            var dac = new Mcp4725Minimal(transport);               // construct driver, (transport) → Mcp4725Minimal
+
+            while (true) {
+                dac.setVoltage(0.0);   // set output to 0 V, (fraction=0.0–1.0) → void
+                Thread.sleep(1000);
+                dac.setVoltage(0.5);   // set output to 50% of VDD, (fraction=0.0–1.0) → void
+                Thread.sleep(1000);
+                dac.setVoltage(1.0);   // set output to VDD, (fraction=0.0–1.0) → void
+                Thread.sleep(1000);
+            }
+        } finally {
+            pi4j.shutdown();
+        }
+    }
+}

--- a/jvm/examples/java/power/ina219/Complete.java
+++ b/jvm/examples/java/power/ina219/Complete.java
@@ -1,0 +1,74 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.power.Ina219Full;
+
+public class Complete {
+    public static void main(String[] args) throws Exception {
+        var pi4j = Pi4J.newAutoContext();                              // initialise Pi4J, () → Context
+        try (var transport = new I2CTransport(pi4j, 1, 0x40)) {      // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+            var ina = new Ina219Full(transport, 0.1, 2.0);            // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina219Full
+
+            ina.configure(                                             // write configuration register, (brng, pga, badc, sadc, mode) → void
+                    Ina219Full.BRNG_32V,                              // bus range 32 V full-scale
+                    Ina219Full.PGA_8,                                  // PGA /8: ±320 mV shunt range
+                    Ina219Full.ADC_12BIT,                              // bus ADC 12-bit single sample
+                    Ina219Full.ADC_12BIT,                              // shunt ADC 12-bit single sample
+                    Ina219Full.MODE_SHUNT_BUS_CONT);                  // continuous shunt+bus measurement
+                                                                      // packs all fields into config reg 0x00 and writes it atomically
+
+            double v = ina.voltage();                                  // read bus voltage, () → double V
+                                                                      // right-shifts raw register by 3, multiplies by 4 mV LSB
+            double vs = ina.shuntVoltage();                           // read shunt voltage, () → double V
+                                                                      // interprets raw register as signed 16-bit, multiplies by 10 µV LSB
+            double i  = ina.current();                                // read current, () → double A
+                                                                      // interprets raw register as signed 16-bit, multiplies by Current_LSB
+            double p  = ina.power();                                  // read power, () → double W
+                                                                      // interprets raw register as unsigned 16-bit, multiplies by Power_LSB (= 20 × Current_LSB)
+            System.out.printf("V_bus=%.3f V  V_shunt=%.6f V  I=%.4f A  P=%.4f W%n", v, vs, i, p);
+
+            boolean ready = ina.conversionReady();                    // read conversion-ready flag, () → boolean
+                                                                      // tests CNVR bit (bit 1) of Bus Voltage register; set when new result available
+            boolean ovf   = ina.overflow();                           // read math overflow flag, () → boolean
+                                                                      // tests OVF bit (bit 0) of Bus Voltage register; set on current/power overflow
+            System.out.println("conversionReady=" + ready + "  overflow=" + ovf);
+
+            // Switch to one-shot triggered mode with 128-sample averaging
+            ina.configure(                                             // write configuration register, (brng, pga, badc, sadc, mode) → void
+                    Ina219Full.BRNG_32V,
+                    Ina219Full.PGA_8,
+                    Ina219Full.ADC_AVG_128,                            // 128-sample average, 68 ms conversion
+                    Ina219Full.ADC_AVG_128,
+                    Ina219Full.MODE_SHUNT_BUS_TRIG);                  // single-shot triggered
+
+            ina.trigger();                                             // trigger a one-shot conversion, () → void
+                                                                      // re-writes the cached config register; starts a new conversion in triggered mode
+            Thread.sleep(150);                                        // wait for 128-sample conversion (~68 ms × 2 channels + margin)
+
+            System.out.printf("triggered V=%.3f V  I=%.4f A%n", ina.voltage(), ina.current());
+
+            ina.shutdown();                                            // enter power-down mode, () → void
+                                                                      // writes config reg with MODE=000 (power-down); ADC powered off
+            Thread.sleep(10);
+
+            ina.wake();                                                // exit power-down, restore configuration, () → void
+                                                                      // re-writes the full cached config register including original MODE bits
+            Thread.sleep(10);
+
+            ina.reset();                                               // software reset and restore config+calibration, () → void
+                                                                      // sets RST bit (bit 15), then re-writes config and recomputes CAL register
+            Thread.sleep(10);
+
+            System.out.printf("after reset V=%.3f V%n", ina.voltage());
+
+        } finally {
+            pi4j.shutdown();
+        }
+    }
+}

--- a/jvm/examples/java/power/ina219/Demo.java
+++ b/jvm/examples/java/power/ina219/Demo.java
@@ -1,0 +1,97 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.power.Ina219Full;
+
+/**
+ * Power-supply sanity check: poll the INA219 once per second for 10 seconds,
+ * printing bus voltage, current, and power. A prompt between samples 4 and 5
+ * lets the user switch on the load mid-run. After the run, min/max/mean of
+ * each measured quantity are reported.
+ */
+public class Demo {
+
+    private static final int    SAMPLES   = 10;
+    private static final long   PERIOD_MS = 1000;
+
+    public static void main(String[] args) throws Exception {
+        var pi4j = Pi4J.newAutoContext();                              // initialise Pi4J, () → Context
+        try (var transport = new I2CTransport(pi4j, 1, 0x40)) {      // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+            var ina = new Ina219Full(transport, 0.1, 2.0);            // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina219Full
+
+            // --- Configure for noise-sensitive power rail monitoring ---
+            // 128-sample averaging suppresses switching noise on a noisy 5 V rail;
+            // continuous mode avoids re-triggering overhead between measurements.
+            ina.configure(Ina219Full.BRNG_32V, Ina219Full.PGA_8,
+                          Ina219Full.ADC_AVG_128, Ina219Full.ADC_AVG_128,
+                          Ina219Full.MODE_SHUNT_BUS_CONT);            // configure ADC, (brng, pga, badc, sadc, mode) → void
+
+            double[] voltages  = new double[SAMPLES];
+            double[] currents  = new double[SAMPLES];
+            double[] powers    = new double[SAMPLES];
+
+            System.out.println("=== INA219 power-supply sanity check ===");
+            System.out.printf("%-4s  %-10s  %-10s  %-10s%n", "#", "V_bus (V)", "I (A)", "P (W)");
+
+            // --- Collect 10 one-second samples ---
+            // Samples 1–4 are taken with the load in its initial state.
+            // After sample 4 the user is prompted to switch the load on,
+            // making the current step visible in the data.
+            for (int n = 0; n < SAMPLES; n++) {
+                if (n == 4) {
+                    System.out.println("Switch on load now...");
+                }
+
+                double v = ina.voltage();    // read bus voltage, () → double V
+                double i = ina.current();    // read current, () → double A
+                double p = ina.power();      // read power, () → double W
+
+                voltages[n] = v;
+                currents[n] = i;
+                powers[n]   = p;
+
+                System.out.printf("%-4d  %-10.3f  %-10.4f  %-10.4f%n", n + 1, v, i, p);
+                Thread.sleep(PERIOD_MS);
+            }
+
+            // --- Compute and print summary statistics ---
+            // Min/max/mean give a quick overview of load stability and
+            // reveal any voltage sag under load.
+            System.out.println("\n=== Summary ===");
+            System.out.printf("%-12s  %-10s  %-10s  %-10s%n", "", "V_bus (V)", "I (A)", "P (W)");
+            System.out.printf("%-12s  %-10.3f  %-10.4f  %-10.4f%n",
+                    "min", min(voltages), min(currents), min(powers));
+            System.out.printf("%-12s  %-10.3f  %-10.4f  %-10.4f%n",
+                    "max", max(voltages), max(currents), max(powers));
+            System.out.printf("%-12s  %-10.3f  %-10.4f  %-10.4f%n",
+                    "mean", mean(voltages), mean(currents), mean(powers));
+
+        } finally {
+            pi4j.shutdown();
+        }
+    }
+
+    private static double min(double[] a) {
+        double m = a[0];
+        for (double x : a) if (x < m) m = x;
+        return m;
+    }
+
+    private static double max(double[] a) {
+        double m = a[0];
+        for (double x : a) if (x > m) m = x;
+        return m;
+    }
+
+    private static double mean(double[] a) {
+        double s = 0;
+        for (double x : a) s += x;
+        return s / a.length;
+    }
+}

--- a/jvm/examples/java/power/ina219/Minimal.java
+++ b/jvm/examples/java/power/ina219/Minimal.java
@@ -1,0 +1,30 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.power.Ina219Minimal;
+
+public class Minimal {
+    public static void main(String[] args) throws Exception {
+        var pi4j = Pi4J.newAutoContext();                              // initialise Pi4J, () → Context
+        try (var transport = new I2CTransport(pi4j, 1, 0x40)) {      // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+            var ina = new Ina219Minimal(transport);                    // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina219Minimal
+
+            while (true) {
+                double v  = ina.voltage();       // read bus voltage, () → double V
+                double vs = ina.shuntVoltage();  // read shunt voltage, () → double V
+                double i  = ina.current();       // read current, () → double A
+                double p  = ina.power();         // read power, () → double W
+                System.out.printf("V_bus=%.3f V  V_shunt=%.6f V  I=%.4f A  P=%.4f W%n", v, vs, i, p);
+                Thread.sleep(1000);
+            }
+        } finally {
+            pi4j.shutdown();
+        }
+    }
+}

--- a/jvm/examples/java/power/ina226/Complete.java
+++ b/jvm/examples/java/power/ina226/Complete.java
@@ -1,0 +1,69 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.power.Ina226Full;
+
+public class Complete {
+    public static void main(String[] args) throws Exception {
+        var pi4j = Pi4J.newAutoContext();                                   // initialise Pi4J, () → Context
+        try (var transport = new I2CTransport(pi4j, 1, 0x40)) {            // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+
+            var ina = new Ina226Full(transport, 0.1, 2.0);                 // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina226Full
+
+            double v  = ina.voltage();                                      // read bus voltage, () → double V
+                                                                            // unsigned 16-bit, 1.25 mV per LSB
+            double vs = ina.shuntVoltage();                                 // read shunt voltage, () → double V
+                                                                            // signed 16-bit, 2.5 µV per LSB
+            double c  = ina.current();                                      // read current, () → double A
+                                                                            // signed, Current_LSB = maxCurrent / 32768 per bit
+            double p  = ina.power();                                        // read power, () → double W
+                                                                            // unsigned, power = 25 × Current_LSB × raw
+            System.out.printf("V=%.3f V  Vshunt=%.6f V  I=%.4f A  P=%.4f W%n", v, vs, c, p);
+
+            ina.configure(Ina226Full.AVG_128, Ina226Full.CT_1100US,        // configure ADC, (avg=4, vbusCt=4, vshCt=4, mode=7) → void
+                          Ina226Full.CT_1100US, Ina226Full.MODE_SHUNT_BUS_CONT);
+                                                                            // sets 128-sample averaging and 1.1 ms conversion times; continuous mode
+
+            boolean ready = ina.conversionReady();                         // check conversion ready flag, () → boolean
+                                                                            // reads CVRF bit (bit 3) from Mask/Enable register
+            System.out.println("Conversion ready: " + ready);
+
+            boolean ovf = ina.overflow();                                   // check math overflow flag, () → boolean
+                                                                            // reads OVF bit (bit 2) from Mask/Enable register
+            System.out.println("Overflow: " + ovf);
+
+            ina.setAlert(Ina226Full.POL, 1.0);                             // set power over-limit alert to 1 W, (function=POL, limit=1.0 W) → void
+                                                                            // writes function to Mask/Enable, limit raw = int(1.0 / (25 × Current_LSB)) to Alert Limit
+
+            int flags = ina.alertFlags();                                   // read alert flags, () → int
+                                                                            // reads Mask/Enable register; reading also clears the alert latch
+            System.out.printf("Alert flags: 0x%04X%n", flags);
+
+            int mfrId = ina.manufacturerId();                               // read manufacturer ID, () → int
+                                                                            // should return 0x5449 ("TI")
+            int dieId = ina.dieId();                                        // read die ID, () → int
+                                                                            // should return 0x2260 for INA226
+            System.out.printf("Manufacturer ID: 0x%04X  Die ID: 0x%04X%n", mfrId, dieId);
+
+            ina.shutdown();                                                 // enter power-down mode, () → void
+                                                                            // sets MODE=000; previously active mode stored for wake()
+            Thread.sleep(100);
+
+            ina.wake();                                                     // restore previous operating mode, () → void
+                                                                            // writes previously stored mode bits back to Configuration register
+            Thread.sleep(10);
+
+            ina.reset();                                                    // reset chip and re-write calibration, () → void
+                                                                            // sets RST bit; chip returns to 0x4127; calibration re-written
+
+        } finally {
+            pi4j.shutdown();
+        }
+    }
+}

--- a/jvm/examples/java/power/ina226/Demo.java
+++ b/jvm/examples/java/power/ina226/Demo.java
@@ -1,0 +1,84 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.power.Ina226Full;
+
+/**
+ * Power-supply monitoring demo: poll voltage, current, and power once per second
+ * for 10 seconds, track min/max/mean, and demonstrate a power over-limit alert.
+ *
+ * Between samples 4 and 5 the user is prompted to switch on a load so that the
+ * effect of load variation is visible in the statistics. The power over-limit
+ * alert is set to 1 W; alertFlags() is checked on every iteration.
+ */
+public class Demo {
+
+    private static final int    SAMPLES      = 10;
+    private static final long   INTERVAL_MS  = 1000;
+    private static final double ALERT_POWER  = 1.0;  // W
+
+    public static void main(String[] args) throws Exception {
+        var pi4j = Pi4J.newAutoContext();                                   // initialise Pi4J, () → Context
+        try (var transport = new I2CTransport(pi4j, 1, 0x40)) {            // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+            var ina = new Ina226Full(transport, 0.1, 2.0);                 // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina226Full
+
+            // --- Configure for noise-sensitive power rail monitoring ---
+            // 128-sample averaging suppresses switching noise on a noisy supply;
+            // continuous mode avoids re-triggering overhead between measurements.
+            ina.configure(Ina226Full.AVG_128, Ina226Full.CT_1100US,        // configure ADC, (avg=4, vbusCt=4, vshCt=4, mode=7) → void
+                          Ina226Full.CT_1100US, Ina226Full.MODE_SHUNT_BUS_CONT);
+
+            // --- Arm a power over-limit alert at 1 W ---
+            // The POL function asserts the ALERT pin and sets the OVF latch when
+            // the calculated power register exceeds the threshold. We poll alertFlags()
+            // on each iteration instead of wiring a GPIO interrupt.
+            ina.setAlert(Ina226Full.POL, ALERT_POWER);                     // set power over-limit alert, (function=POL, limit=1.0 W) → void
+
+            double minV = Double.MAX_VALUE, maxV = -Double.MAX_VALUE, sumV = 0;
+            double minI = Double.MAX_VALUE, maxI = -Double.MAX_VALUE, sumI = 0;
+            double minP = Double.MAX_VALUE, maxP = -Double.MAX_VALUE, sumP = 0;
+
+            for (int i = 0; i < SAMPLES; i++) {
+                if (i == 4) {
+                    System.out.println("Switch on load now...");
+                }
+
+                double v = ina.voltage();      // read bus voltage, () → double V
+                double c = ina.current();      // read current, () → double A
+                double p = ina.power();        // read power, () → double W
+
+                int alertRaw = ina.alertFlags();  // read alert flags (clears latch), () → int
+
+                boolean alert = (alertRaw & Ina226Full.POL) != 0;
+                System.out.printf("Sample %2d: V=%.3f V  I=%.4f A  P=%.4f W%s%n",
+                        i + 1, v, c, p, alert ? "  [ALERT: power over limit]" : "");
+
+                minV = Math.min(minV, v); maxV = Math.max(maxV, v); sumV += v;
+                minI = Math.min(minI, c); maxI = Math.max(maxI, c); sumI += c;
+                minP = Math.min(minP, p); maxP = Math.max(maxP, p); sumP += p;
+
+                Thread.sleep(INTERVAL_MS);
+            }
+
+            // --- Print summary statistics ---
+            // Min/max/mean over the 10-second window gives a compact view of
+            // supply stability and load variation.
+            System.out.println();
+            System.out.printf("Bus voltage  — min=%.3f V   max=%.3f V   mean=%.3f V%n",
+                    minV, maxV, sumV / SAMPLES);
+            System.out.printf("Current      — min=%.4f A  max=%.4f A  mean=%.4f A%n",
+                    minI, maxI, sumI / SAMPLES);
+            System.out.printf("Power        — min=%.4f W  max=%.4f W  mean=%.4f W%n",
+                    minP, maxP, sumP / SAMPLES);
+
+        } finally {
+            pi4j.shutdown();
+        }
+    }
+}

--- a/jvm/examples/java/power/ina226/Minimal.java
+++ b/jvm/examples/java/power/ina226/Minimal.java
@@ -1,0 +1,30 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.power.Ina226Minimal;
+
+public class Minimal {
+    public static void main(String[] args) throws Exception {
+        var pi4j = Pi4J.newAutoContext();                                   // initialise Pi4J, () → Context
+        try (var transport = new I2CTransport(pi4j, 1, 0x40)) {            // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+            var ina = new Ina226Minimal(transport, 0.1, 2.0);              // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina226Minimal
+
+            for (int i = 0; i < 10; i++) {
+                double v  = ina.voltage();       // read bus voltage, () → double V
+                double vs = ina.shuntVoltage();  // read shunt voltage, () → double V
+                double c  = ina.current();       // read current, () → double A
+                double p  = ina.power();         // read power, () → double W
+                System.out.printf("V=%.3f V  Vshunt=%.6f V  I=%.4f A  P=%.4f W%n", v, vs, c, p);
+                Thread.sleep(1000);
+            }
+        } finally {
+            pi4j.shutdown();
+        }
+    }
+}

--- a/jvm/examples/java/power/ina3221/Complete.java
+++ b/jvm/examples/java/power/ina3221/Complete.java
@@ -1,0 +1,91 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.power.Ina3221Full;
+
+public class Complete {
+    public static void main(String[] args) throws Exception {
+        var pi4j = Pi4J.newAutoContext();                                    // initialise Pi4J, () → Context
+        try (var transport = new I2CTransport(pi4j, 1, 0x40)) {            // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+            var ina = new Ina3221Full(transport);                           // construct driver (0.1 Ω shunt all channels), (transport) → Ina3221Full
+
+            ina.configure(1, 4, 4, Ina3221Full.MODE_SHUNT_BUS_CONT);       // configure averaging and conversion times, (avg=0–7, vbusCt=0–7, vshCt=0–7, mode=0–7) → void
+                                                                            // avg=1 means 4-sample average; vbusCt/vshCt=4 means 1.1 ms each
+
+            for (int ch = 1; ch <= 3; ch++) {
+                ina.enableChannel(ch, true);                                // enable a channel, (channel=1–3, enabled) → void
+                                                                            // sets the CH<n>en bit in the configuration register
+                boolean en = ina.channelEnabled(ch);                        // read channel enable state, (channel=1–3) → boolean
+                                                                            // true when the CH<n>en bit is set
+                System.out.printf("CH%d enabled: %b%n", ch, en);
+            }
+
+            for (int ch = 1; ch <= 3; ch++) {
+                double v  = ina.voltage(ch);                                // read bus voltage, (channel=1–3) → double V
+                                                                            // left-aligned 12-bit unsigned, 8 mV LSB
+                double sv = ina.shuntVoltage(ch);                          // read shunt voltage, (channel=1–3) → double V
+                                                                            // left-aligned 13-bit signed, 40 µV LSB
+                double i  = ina.current(ch);                               // compute current from shunt voltage, (channel=1–3) → double A
+                                                                            // current = shuntVoltage / rShunt
+                double p  = ina.power(ch);                                 // compute power, (channel=1–3) → double W
+                                                                            // power = busVoltage × current
+                System.out.printf("CH%d: %.3f V  %.6f V_shunt  %.4f A  %.4f W%n", ch, v, sv, i, p);
+            }
+
+            boolean cvrf = ina.conversionReady();                          // read conversion-ready flag, () → boolean
+                                                                            // CVRF bit (bit 0) of Mask/Enable register; set after each full conversion
+            System.out.println("Conversion ready: " + cvrf);
+
+            ina.setCriticalAlert(1, 0.05);                                 // set critical alert on channel 1, (channel=1–3, limitV) → void
+                                                                            // alert fires when |shunt voltage| exceeds this threshold
+            ina.setWarningAlert(1, 0.04);                                  // set warning alert on channel 1, (channel=1–3, limitV) → void
+                                                                            // alert fires when |shunt voltage| exceeds this threshold
+            ina.setCriticalAlert(2, 0.05);                                 // set critical alert on channel 2, (channel=1–3, limitV) → void
+            ina.setWarningAlert(2, 0.04);                                  // set warning alert on channel 2, (channel=1–3, limitV) → void
+            ina.setCriticalAlert(3, 0.05);                                 // set critical alert on channel 3, (channel=1–3, limitV) → void
+            ina.setWarningAlert(3, 0.04);                                  // set warning alert on channel 3, (channel=1–3, limitV) → void
+
+            ina.setPowerValidLimits(5.5, 4.5);                             // set power-valid thresholds, (upperV, lowerV) → void
+                                                                            // PVF bit set when all enabled bus voltages are within [lowerV, upperV]
+            boolean pv = ina.powerValid();                                  // read power-valid flag, () → boolean
+                                                                            // PVF bit (bit 2) of Mask/Enable register
+            System.out.println("Power valid: " + pv);
+
+            ina.setSummationChannels(new int[]{1, 2, 3}, 0.1);            // enable summation for all channels with limit, (channels, limitV) → void
+                                                                            // sets SCC bits in Mask/Enable and writes the sum limit register
+            double sumV = ina.summationValue();                             // read shunt-voltage sum, () → double V
+                                                                            // 14-bit signed, left-aligned by 1; LSB = 20 µV
+            System.out.printf("Shunt voltage sum: %.6f V%n", sumV);
+
+            int flags = ina.alertFlags();                                   // read and clear alert flags, () → int
+                                                                            // reads Mask/Enable register; clears latched flags; inspect against CF1/WF1/PVF etc.
+            System.out.printf("Alert flags: 0x%04X%n", flags);
+
+            int mfr = ina.manufacturerId();                                 // read manufacturer ID, () → int
+                                                                            // expected 0x5449 ("TI")
+            int die = ina.dieId();                                          // read die ID, () → int
+                                                                            // expected 0x3220
+            System.out.printf("Manufacturer ID: 0x%04X  Die ID: 0x%04X%n", mfr, die);
+
+            ina.shutdown();                                                  // enter power-down mode (MODE=000), () → void
+                                                                            // saves current MODE so wake() can restore it
+            Thread.sleep(100);
+
+            ina.wake();                                                      // restore saved operating mode, () → void
+                                                                            // writes previously saved MODE bits back into config register
+            Thread.sleep(100);
+
+            ina.reset();                                                     // software reset via RST bit, then restore saved mode, () → void
+                                                                            // resets all registers to hardware defaults, then writes saved MODE back
+
+        } finally {
+            pi4j.shutdown();
+        }
+    }
+}

--- a/jvm/examples/java/power/ina3221/Demo.java
+++ b/jvm/examples/java/power/ina3221/Demo.java
@@ -1,0 +1,115 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.power.Ina3221Full;
+
+/**
+ * Three-rail power monitor demo.
+ *
+ * Wire the INA3221 across three power rails (e.g. 3.3 V, 5 V, 12 V) each with
+ * a 0.1 Ω shunt. The script polls all three channels once per second for 30 s,
+ * printing a tabular row per second. At t=10 s it arms critical alerts at 1.5×
+ * the observed current draw on each channel. At t=20 s it enables summation
+ * across all three channels. After the run it dumps the final alert flags.
+ */
+public class Demo {
+
+    private static final int    POLL_S    = 30;
+    private static final double R_SHUNT   = 0.1; // Ω
+    private static final double ALERT_MUL = 1.5;
+
+    public static void main(String[] args) throws Exception {
+        var pi4j = Pi4J.newAutoContext();                                    // initialise Pi4J, () → Context
+        try (var transport = new I2CTransport(pi4j, 1, 0x40)) {            // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+
+            // --- Construct driver with 0.1 Ω shunt on all rails ---
+            // Using a common shunt value simplifies wiring; per-channel values can
+            // be supplied via the double[] constructor if rails differ.
+            var ina = new Ina3221Full(transport, R_SHUNT);                  // construct driver, (transport, rShunt=0.1 Ω) → Ina3221Full
+
+            // --- Configure: 4-sample averaging, 1.1 ms conversions, continuous mode ---
+            // 4-sample averaging reduces noise on switching-mode supplies without
+            // significantly increasing the effective sample interval (~10 ms total).
+            ina.configure(1, 4, 4, Ina3221Full.MODE_SHUNT_BUS_CONT);       // configure ADC, (avg=1→4 samples, vbusCt=4, vshCt=4, mode=7) → void
+
+            // --- Snapshot arrays to track initial draw for alert arming ---
+            double[] firstI = new double[]{0, 0, 0};
+            boolean alertsArmed = false;
+            boolean summationEnabled = false;
+
+            System.out.printf("%-5s  %-24s  %-24s  %-24s%n",
+                    "t(s)", "--- CH1 V/A/W ---", "--- CH2 V/A/W ---", "--- CH3 V/A/W ---");
+            System.out.println("-".repeat(85));
+
+            for (int t = 0; t < POLL_S; t++) {
+
+                // --- Poll all three channels ---
+                // Each read is two I²C transactions (bus + shunt register). Current
+                // and power are derived in software — no hardware division needed.
+                double[] v = new double[4];
+                double[] i = new double[4];
+                double[] p = new double[4];
+                for (int ch = 1; ch <= 3; ch++) {
+                    v[ch] = ina.voltage(ch);                                // read bus voltage, (channel=1–3) → double V
+                    i[ch] = ina.current(ch);                                // compute current, (channel=1–3) → double A
+                    p[ch] = ina.power(ch);                                  // compute power, (channel=1–3) → double W
+                }
+
+                if (t == 0) {
+                    for (int ch = 1; ch <= 3; ch++) firstI[ch - 1] = i[ch];
+                }
+
+                System.out.printf("%-5d  %6.3f V %6.3f A %6.3f W  %6.3f V %6.3f A %6.3f W  %6.3f V %6.3f A %6.3f W%n",
+                        t,
+                        v[1], i[1], p[1],
+                        v[2], i[2], p[2],
+                        v[3], i[3], p[3]);
+
+                // --- At t=10 s: arm critical alerts at 1.5× initial draw ---
+                // Setting the limit as a shunt voltage: limit_V = current × rShunt × 1.5.
+                // This lets the hardware flag transient spikes without software polling.
+                if (t == 10 && !alertsArmed) {
+                    for (int ch = 1; ch <= 3; ch++) {
+                        double limit = Math.abs(firstI[ch - 1]) * R_SHUNT * ALERT_MUL;
+                        if (limit < 40e-6) limit = 40e-6; // minimum 1 LSB
+                        ina.setCriticalAlert(ch, limit);                    // set critical alert, (channel=1–3, limitV) → void
+                    }
+                    System.out.println("  [t=10] Critical alerts armed at 1.5x initial draw");
+                    alertsArmed = true;
+                }
+
+                // --- At t=20 s: enable summation across all three channels ---
+                // Summation lets the hardware accumulate shunt voltages; the sum
+                // register gives total power-bus current in a single read.
+                if (t == 20 && !summationEnabled) {
+                    double sumLimit = (Math.abs(firstI[0]) + Math.abs(firstI[1]) + Math.abs(firstI[2]))
+                                      * R_SHUNT * ALERT_MUL;
+                    if (sumLimit < 40e-6) sumLimit = 40e-6;
+                    ina.setSummationChannels(new int[]{1, 2, 3}, sumLimit); // enable all-channel summation, (channels, limitV) → void
+                    System.out.println("  [t=20] Summation enabled for channels 1+2+3");
+                    summationEnabled = true;
+                }
+
+                Thread.sleep(1000);
+            }
+
+            // --- Final alert flag dump ---
+            // Reading Mask/Enable clears latched flags; inspect individual bits.
+            int flags = ina.alertFlags();                                    // read and clear alert flags, () → int
+            System.out.printf("%nFinal alert flags: 0x%04X%n", flags);
+            if ((flags & Ina3221Full.CF1) != 0) System.out.println("  Critical alert fired on CH1");
+            if ((flags & Ina3221Full.CF2) != 0) System.out.println("  Critical alert fired on CH2");
+            if ((flags & Ina3221Full.CF3) != 0) System.out.println("  Critical alert fired on CH3");
+            if ((flags & Ina3221Full.SF)  != 0) System.out.println("  Summation alert fired");
+
+        } finally {
+            pi4j.shutdown();
+        }
+    }
+}

--- a/jvm/examples/java/power/ina3221/Minimal.java
+++ b/jvm/examples/java/power/ina3221/Minimal.java
@@ -1,0 +1,32 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.power.Ina3221Minimal;
+
+public class Minimal {
+    public static void main(String[] args) throws Exception {
+        var pi4j = Pi4J.newAutoContext();                                    // initialise Pi4J, () → Context
+        try (var transport = new I2CTransport(pi4j, 1, 0x40)) {            // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+            var ina = new Ina3221Minimal(transport);                        // construct driver (0.1 Ω shunt all channels), (transport) → Ina3221Minimal
+
+            while (true) {
+                for (int ch = 1; ch <= 3; ch++) {
+                    double v = ina.voltage(ch);                             // read bus voltage, (channel=1–3) → double V
+                    double i = ina.current(ch);                             // compute current via shunt, (channel=1–3) → double A
+                    double p = ina.power(ch);                               // compute power, (channel=1–3) → double W
+                    System.out.printf("CH%d: %.3f V  %.4f A  %.4f W%n", ch, v, i, p);
+                }
+                System.out.println("---");
+                Thread.sleep(1000);
+            }
+        } finally {
+            pi4j.shutdown();
+        }
+    }
+}

--- a/jvm/examples/java/pressure/bmp180/Complete.java
+++ b/jvm/examples/java/pressure/bmp180/Complete.java
@@ -1,0 +1,61 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.pressure.Bmp180Full;
+
+public class Complete {
+    public static void main(String[] args) throws Exception {
+        var pi4j = Pi4J.newAutoContext();                                // initialise Pi4J, () → Context
+        try (var transport = new I2CTransport(pi4j, 1, 0x77)) {        // open I²C bus 1, device 0x77, (bus, address=0x77) → I2CTransport
+            var sensor = new Bmp180Full(transport);                      // construct driver, verifies chip ID and loads calibration, (transport) → Bmp180Full
+
+            int id = sensor.chipId();                                    // read chip ID register 0xD0, () → int
+                                                                         // returns 0x55 for BMP180; useful for confirming the device is present
+            System.out.printf("chip ID: 0x%02X%n", id);
+
+            int oss = sensor.oversampling();                             // read current OSS setting, () → int
+                                                                         // 0 = ultra-low-power (default), 1 = standard, 2 = high-res, 3 = ultra-high-res
+            System.out.println("oversampling: " + oss);
+
+            sensor.setOversampling(Bmp180Full.OSS_HIGH_RES);            // set oversampling to high-resolution mode, (oss=0–3) → void
+                                                                         // OSS = 2: 4 internal samples averaged, ~13.5 ms conversion time
+
+            double t = sensor.temperature();                             // read temperature, () → double °C
+                                                                         // triggers a 5 ms ADC conversion, applies Bosch integer compensation
+            System.out.printf("temperature: %.2f °C%n", t);
+
+            double p = sensor.pressure();                                // read pressure, () → double hPa
+                                                                         // re-reads temperature to refresh B5, then triggers pressure ADC
+            System.out.printf("pressure: %.2f hPa%n", p);
+
+            double alt = sensor.altitude();                              // compute altitude using default sea-level pressure 1013.25 hPa, () → double m
+                                                                         // applies barometric formula: 44330 × (1 − (p/1013.25)^(1/5.255))
+            System.out.printf("altitude: %.1f m%n", alt);
+
+            double altRef = sensor.altitude(1013.00);                   // compute altitude with custom sea-level pressure, (seaLevelHpa=1013.25 hPa) → double m
+                                                                         // use local QNH for accurate terrain altitude
+            System.out.printf("altitude (QNH 1013.00): %.1f m%n", altRef);
+
+            double slp = sensor.seaLevelPressure(50.0);                 // back-calculate sea-level pressure at known altitude, (altitudeM=0.0 m) → double hPa
+                                                                         // reduces station pressure to MSL using the barometric formula inverse
+            System.out.printf("sea-level pressure at 50 m: %.2f hPa%n", slp);
+
+            sensor.reset();                                              // soft-reset the chip and reload calibration, () → void
+                                                                         // writes 0xB6 to 0xE0, waits 15 ms, then re-reads calibration EEPROM
+
+            sensor.setOversampling(Bmp180Full.OSS_ULP);                 // restore ultra-low-power mode, (oss=0–3) → void
+                                                                         // OSS = 0: single sample, ~4.5 ms, lowest power consumption
+
+            System.out.println("oversampling after reset: " + sensor.oversampling()); // read current OSS setting, () → int
+                                                                                        // reset() restores chip but local field retains 0 since it was set after construction
+        } finally {
+            pi4j.shutdown();
+        }
+    }
+}

--- a/jvm/examples/java/pressure/bmp180/Demo.java
+++ b/jvm/examples/java/pressure/bmp180/Demo.java
@@ -1,0 +1,94 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.pressure.Bmp180Full;
+
+/**
+ * Pocket altimeter: 60-second run at 1 Hz in ULP mode.
+ *
+ * The first reading establishes the sea-level reference so altitude starts at 0.
+ * Each subsequent reading reports temperature, pressure, altitude, and vertical
+ * displacement (in cm) relative to the reference. After the run, prints
+ * min/max/mean for all three quantities.
+ */
+public class Demo {
+
+    private static final int    SAMPLES     = 60;
+    private static final long   INTERVAL_MS = 1000;
+
+    public static void main(String[] args) throws Exception {
+        var pi4j = Pi4J.newAutoContext();                               // initialise Pi4J, () → Context
+        try (var transport = new I2CTransport(pi4j, 1, 0x77)) {       // open I²C bus 1, device 0x77 (fixed address), (bus, address=0x77) → I2CTransport
+            var sensor = new Bmp180Full(transport);                     // construct driver, verifies chip ID, reads calibration, (transport) → Bmp180Full
+
+            // --- Configure for low-power continuous monitoring ---
+            // ULP mode (OSS = 0) minimises power draw (~3 µA RMS) and conversion time
+            // (~4.5 ms). For a pocket altimeter taking one sample per second the
+            // extra resolution of higher OSS is not needed; ULP resolves ~1 m.
+            sensor.setOversampling(Bmp180Full.OSS_ULP);                // set ultra-low-power mode, (oss=0–3) → void
+
+            // --- Take first reading to establish reference altitude ---
+            // The sea-level pressure derived from this reading anchors altitude = 0.
+            // Any subsequent change in pressure will appear as vertical displacement.
+            double firstPressure = sensor.pressure();                   // read pressure for reference, () → double hPa
+            double seaLevel      = sensor.seaLevelPressure(0.0);       // derive sea-level pressure at altitude = 0, (altitudeM=0.0 m) → double hPa
+            double firstTemp     = sensor.temperature();                // read temperature for reference, () → double °C
+            double firstAlt      = sensor.altitude(seaLevel);          // compute altitude (should be ~0), (seaLevelHpa) → double m
+
+            System.out.printf("Reference: temperature=%.2f °C  pressure=%.2f hPa  altitude=%.1f m  (sea-level ref=%.2f hPa)%n",
+                    firstTemp, firstPressure, firstAlt, seaLevel);
+
+            double[] temps     = new double[SAMPLES];
+            double[] pressures = new double[SAMPLES];
+            double[] altitudes = new double[SAMPLES];
+
+            // --- 60-second sampling loop ---
+            // Each iteration reads temperature, pressure, and altitude; prints the
+            // current values plus vertical displacement from the reference position.
+            for (int i = 0; i < SAMPLES; i++) {
+                double t   = sensor.temperature();                      // read temperature, () → double °C
+                double p   = sensor.pressure();                         // read pressure, () → double hPa
+                double alt = sensor.altitude(seaLevel);                 // compute altitude relative to reference, (seaLevelHpa) → double m
+                double dAlt = alt - firstAlt;
+
+                temps[i]     = t;
+                pressures[i] = p;
+                altitudes[i] = alt;
+
+                String direction = dAlt > 0.005 ? "up" : dAlt < -0.005 ? "down" : "level";
+                System.out.printf("[%2d] temperature=%.2f °C  pressure=%.2f hPa  altitude=%.1f m  moved %s %.0f cm%n",
+                        i + 1, t, p, alt, direction, Math.abs(dAlt) * 100);
+
+                Thread.sleep(INTERVAL_MS);
+            }
+
+            // --- Print summary statistics ---
+            // After the run, report the full range and mean for each quantity so
+            // the user can see how much the environment changed during the session.
+            double minT = temps[0], maxT = temps[0], sumT = 0;
+            double minP = pressures[0], maxP = pressures[0], sumP = 0;
+            double minA = altitudes[0], maxA = altitudes[0], sumA = 0;
+            for (int i = 0; i < SAMPLES; i++) {
+                minT = Math.min(minT, temps[i]);     maxT = Math.max(maxT, temps[i]);     sumT += temps[i];
+                minP = Math.min(minP, pressures[i]); maxP = Math.max(maxP, pressures[i]); sumP += pressures[i];
+                minA = Math.min(minA, altitudes[i]); maxA = Math.max(maxA, altitudes[i]); sumA += altitudes[i];
+            }
+            System.out.printf("%n--- Summary (%d samples) ---%n", SAMPLES);
+            System.out.printf("Temperature: min=%.2f °C  max=%.2f °C  mean=%.2f °C%n",
+                    minT, maxT, sumT / SAMPLES);
+            System.out.printf("Pressure:    min=%.2f hPa  max=%.2f hPa  mean=%.2f hPa%n",
+                    minP, maxP, sumP / SAMPLES);
+            System.out.printf("Altitude:    min=%.1f m  max=%.1f m  mean=%.1f m%n",
+                    minA, maxA, sumA / SAMPLES);
+
+        } finally {
+            pi4j.shutdown();
+        }
+    }
+}

--- a/jvm/examples/java/pressure/bmp180/Minimal.java
+++ b/jvm/examples/java/pressure/bmp180/Minimal.java
@@ -1,0 +1,28 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.pressure.Bmp180Minimal;
+
+public class Minimal {
+    public static void main(String[] args) throws Exception {
+        var pi4j = Pi4J.newAutoContext();                               // initialise Pi4J, () → Context
+        try (var transport = new I2CTransport(pi4j, 1, 0x77)) {       // open I²C bus 1, device 0x77, (bus, address=0x77) → I2CTransport
+            var sensor = new Bmp180Minimal(transport);                  // construct driver, verifies chip ID and loads calibration, (transport) → Bmp180Minimal
+
+            while (true) {
+                double t = sensor.temperature();                        // read temperature, () → double °C
+                double p = sensor.pressure();                           // read pressure, () → double hPa
+                System.out.printf("temperature=%.2f °C  pressure=%.2f hPa%n", t, p);
+                Thread.sleep(1000);
+            }
+        } finally {
+            pi4j.shutdown();
+        }
+    }
+}

--- a/jvm/examples/kotlin/adc_dac/mcp4725/Complete.kt
+++ b/jvm/examples/kotlin/adc_dac/mcp4725/Complete.kt
@@ -1,0 +1,52 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.adc_dac.Mcp4725Full
+
+fun main() {
+    val pi4j = Pi4J.newAutoContext()                                // initialise Pi4J, () → Context
+    try {
+        I2CTransport(pi4j, 1, 0x60).use { transport ->             // open device transport, (bus, address) → I2CTransport
+        I2CTransport(pi4j, 1, 0x00).use { gcTransport ->           // open general call transport, (bus, address=0x00) → I2CTransport
+
+            val dac = Mcp4725Full(transport, gcTransport)           // construct driver, (transport, generalCall) → Mcp4725Full
+
+            dac.setVoltage(0.5)                                     // set output to 50% of VDD, (fraction=0.0–1.0) → Unit
+                                                                    // converts fraction to 12-bit code and issues a Fast Write
+            dac.setRaw(2048)                                        // set output to raw code, (code=0–4095) → Unit
+                                                                    // maps directly to DAC register; 2048 ≈ 50% of VDD
+            dac.setVoltageEeprom(0.75)                              // set output and persist to EEPROM, (fraction=0.0–1.0) → Unit
+                                                                    // DAC register and EEPROM are both written; output survives power cycle
+            dac.setRawEeprom(3072)                                  // set raw code and persist to EEPROM, (code=0–4095) → Unit
+                                                                    // issues a Write DAC + EEPROM command; takes up to 50 ms
+
+            Thread.sleep(50)                                        // wait for EEPROM write to complete, (ms) → Unit
+
+            val state = dac.read()                                  // read device state, () → ReadResult
+                                                                    // returns DAC register, EEPROM contents, power-down mode, and RDY/BSY flag
+            println("code=${state.code} fraction=%.4f pd=${state.powerDown} eepromCode=${state.eepromCode} eepromPd=${state.eepromPowerDown} ready=${state.eepromReady}"
+                .format(state.voltageFraction))
+
+            dac.setPowerDown(1)                                     // enter power-down mode, (mode=0–3) → Unit
+                                                                    // 1 = 1 kΩ pull-down to GND; output pin goes high-Z
+            Thread.sleep(100)
+
+            dac.wakeUp()                                            // send General Call Wake-Up to all MCP47xx on bus, () → Unit
+                                                                    // clears power-down bits in the DAC register; output resumes
+            dac.reset()                                             // send General Call Reset to all MCP47xx on bus, () → Unit
+                                                                    // triggers internal POR; reloads EEPROM into DAC register
+
+            val ready = dac.isEepromReady()                        // read RDY/BSY bit, () → Boolean
+                                                                    // true when no EEPROM write is in progress
+            println("EEPROM ready: $ready")
+        }}
+    } finally {
+        pi4j.shutdown()
+    }
+}

--- a/jvm/examples/kotlin/adc_dac/mcp4725/Demo.kt
+++ b/jvm/examples/kotlin/adc_dac/mcp4725/Demo.kt
@@ -1,0 +1,55 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.adc_dac.Mcp4725Full
+
+/**
+ * Triangle wave: ramp the DAC from 0 to full scale and back in 1/20 steps,
+ * printing the fraction and approximate voltage at each step (assumes 3.3 V supply).
+ * Makes a visible sawtooth on an oscilloscope and demonstrates 12-bit resolution.
+ */
+
+private const val VDD     = 3.3
+private const val STEPS   = 20
+private const val STEP_MS = 100L
+
+fun main() {
+    val pi4j = Pi4J.newAutoContext()                              // initialise Pi4J, () → Context
+    try {
+        I2CTransport(pi4j, 1, 0x60).use { transport ->           // open I²C bus 1, device 0x60, (bus, address) → I2CTransport
+            val dac = Mcp4725Full(transport, null)                // construct driver (no general call needed for this demo), (transport, generalCall) → Mcp4725Full
+
+            // --- Ramp up from 0 V to VDD ---
+            // Each step covers 1/20 of full scale (~165 mV on a 3.3 V rail).
+            // 100 ms per step gives a 2-second rise time — slow enough to observe
+            // on a multimeter and fast enough to show a clean ramp on an oscilloscope.
+            for (i in 0..STEPS) {
+                val fraction = i.toDouble() / STEPS
+                dac.setVoltage(fraction)                          // set output level, (fraction=0.0–1.0) → Unit
+                println("↑ fraction=%.2f  V≈%.3f V".format(fraction, fraction * VDD))
+                Thread.sleep(STEP_MS)
+            }
+
+            // --- Ramp down from VDD back to 0 V ---
+            // Descending half of the triangle wave.
+            for (i in STEPS - 1 downTo 0) {
+                val fraction = i.toDouble() / STEPS
+                dac.setVoltage(fraction)                          // set output level, (fraction=0.0–1.0) → Unit
+                println("↓ fraction=%.2f  V≈%.3f V".format(fraction, fraction * VDD))
+                Thread.sleep(STEP_MS)
+            }
+
+            // --- Return output to 0 V before exit ---
+            // Avoids leaving the rail at an arbitrary level when the process ends.
+            dac.setRaw(0)                                         // set output to 0 V, (code=0–4095) → Unit
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+}

--- a/jvm/examples/kotlin/adc_dac/mcp4725/Minimal.kt
+++ b/jvm/examples/kotlin/adc_dac/mcp4725/Minimal.kt
@@ -1,0 +1,30 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.adc_dac.Mcp4725Minimal
+
+fun main() {
+    val pi4j = Pi4J.newAutoContext()                            // initialise Pi4J, () → Context
+    try {
+        I2CTransport(pi4j, 1, 0x60).use { transport ->         // open I²C bus 1, device 0x60, (bus, address) → I2CTransport
+            val dac = Mcp4725Minimal(transport)                 // construct driver, (transport) → Mcp4725Minimal
+
+            while (true) {
+                dac.setVoltage(0.0)   // set output to 0 V, (fraction=0.0–1.0) → Unit
+                Thread.sleep(1000)
+                dac.setVoltage(0.5)   // set output to 50% of VDD, (fraction=0.0–1.0) → Unit
+                Thread.sleep(1000)
+                dac.setVoltage(1.0)   // set output to VDD, (fraction=0.0–1.0) → Unit
+                Thread.sleep(1000)
+            }
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+}

--- a/jvm/examples/kotlin/power/ina219/Complete.kt
+++ b/jvm/examples/kotlin/power/ina219/Complete.kt
@@ -1,0 +1,73 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina219Full
+
+fun main() {
+    val pi4j = Pi4J.newAutoContext()                                   // initialise Pi4J, () → Context
+    try {
+        I2CTransport(pi4j, 1, 0x40).use { transport ->                // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+            val ina = Ina219Full(transport, 0.1, 2.0)                  // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina219Full
+
+            ina.configure(                                             // write configuration register, (brng, pga, badc, sadc, mode) → Unit
+                Ina219Full.BRNG_32V,                                   // bus range 32 V full-scale
+                Ina219Full.PGA_8,                                      // PGA /8: ±320 mV shunt range
+                Ina219Full.ADC_12BIT,                                  // bus ADC 12-bit single sample
+                Ina219Full.ADC_12BIT,                                  // shunt ADC 12-bit single sample
+                Ina219Full.MODE_SHUNT_BUS_CONT)                        // continuous shunt+bus measurement
+                                                                      // packs all fields into config reg 0x00 and writes it atomically
+
+            val v  = ina.voltage()                                     // read bus voltage, () → Double V
+                                                                      // right-shifts raw register by 3, multiplies by 4 mV LSB
+            val vs = ina.shuntVoltage()                               // read shunt voltage, () → Double V
+                                                                      // interprets raw register as signed 16-bit, multiplies by 10 µV LSB
+            val i  = ina.current()                                    // read current, () → Double A
+                                                                      // interprets raw register as signed 16-bit, multiplies by Current_LSB
+            val p  = ina.power()                                      // read power, () → Double W
+                                                                      // interprets raw register as unsigned 16-bit, multiplies by Power_LSB (= 20 × Current_LSB)
+            println("V_bus=%.3f V  V_shunt=%.6f V  I=%.4f A  P=%.4f W".format(v, vs, i, p))
+
+            val ready = ina.conversionReady()                         // read conversion-ready flag, () → Boolean
+                                                                      // tests CNVR bit (bit 1) of Bus Voltage register; set when new result available
+            val ovf   = ina.overflow()                                // read math overflow flag, () → Boolean
+                                                                      // tests OVF bit (bit 0) of Bus Voltage register; set on current/power overflow
+            println("conversionReady=$ready  overflow=$ovf")
+
+            // Switch to one-shot triggered mode with 128-sample averaging
+            ina.configure(                                             // write configuration register, (brng, pga, badc, sadc, mode) → Unit
+                Ina219Full.BRNG_32V,
+                Ina219Full.PGA_8,
+                Ina219Full.ADC_AVG_128,                                // 128-sample average, 68 ms conversion
+                Ina219Full.ADC_AVG_128,
+                Ina219Full.MODE_SHUNT_BUS_TRIG)                        // single-shot triggered
+
+            ina.trigger()                                              // trigger a one-shot conversion, () → Unit
+                                                                      // re-writes the cached config register; starts a new conversion in triggered mode
+            Thread.sleep(150)                                         // wait for 128-sample conversion (~68 ms × 2 channels + margin)
+
+            println("triggered V=%.3f V  I=%.4f A".format(ina.voltage(), ina.current()))
+
+            ina.shutdown()                                             // enter power-down mode, () → Unit
+                                                                      // writes config reg with MODE=000 (power-down); ADC powered off
+            Thread.sleep(10)
+
+            ina.wake()                                                 // exit power-down, restore configuration, () → Unit
+                                                                      // re-writes the full cached config register including original MODE bits
+            Thread.sleep(10)
+
+            ina.reset()                                                // software reset and restore config+calibration, () → Unit
+                                                                      // sets RST bit (bit 15), then re-writes config and recomputes CAL register
+            Thread.sleep(10)
+
+            println("after reset V=%.3f V".format(ina.voltage()))
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+}

--- a/jvm/examples/kotlin/power/ina219/Demo.kt
+++ b/jvm/examples/kotlin/power/ina219/Demo.kt
@@ -1,0 +1,78 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina219Full
+
+/**
+ * Power-supply sanity check: poll the INA219 once per second for 10 seconds,
+ * printing bus voltage, current, and power. A prompt between samples 4 and 5
+ * lets the user switch on the load mid-run. After the run, min/max/mean of
+ * each measured quantity are reported.
+ */
+
+private const val SAMPLES   = 10
+private const val PERIOD_MS = 1000L
+
+fun main() {
+    val pi4j = Pi4J.newAutoContext()                                   // initialise Pi4J, () → Context
+    try {
+        I2CTransport(pi4j, 1, 0x40).use { transport ->                // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+            val ina = Ina219Full(transport, 0.1, 2.0)                  // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina219Full
+
+            // --- Configure for noise-sensitive power rail monitoring ---
+            // 128-sample averaging suppresses switching noise on a noisy 5 V rail;
+            // continuous mode avoids re-triggering overhead between measurements.
+            ina.configure(Ina219Full.BRNG_32V, Ina219Full.PGA_8,
+                          Ina219Full.ADC_AVG_128, Ina219Full.ADC_AVG_128,
+                          Ina219Full.MODE_SHUNT_BUS_CONT)              // configure ADC, (brng, pga, badc, sadc, mode) → Unit
+
+            val voltages = DoubleArray(SAMPLES)
+            val currents = DoubleArray(SAMPLES)
+            val powers   = DoubleArray(SAMPLES)
+
+            println("=== INA219 power-supply sanity check ===")
+            println("%-4s  %-10s  %-10s  %-10s".format("#", "V_bus (V)", "I (A)", "P (W)"))
+
+            // --- Collect 10 one-second samples ---
+            // Samples 1–4 are taken with the load in its initial state.
+            // After sample 4 the user is prompted to switch the load on,
+            // making the current step visible in the data.
+            for (n in 0 until SAMPLES) {
+                if (n == 4) {
+                    println("Switch on load now...")
+                }
+
+                val v = ina.voltage()   // read bus voltage, () → Double V
+                val i = ina.current()   // read current, () → Double A
+                val p = ina.power()     // read power, () → Double W
+
+                voltages[n] = v
+                currents[n] = i
+                powers[n]   = p
+
+                println("%-4d  %-10.3f  %-10.4f  %-10.4f".format(n + 1, v, i, p))
+                Thread.sleep(PERIOD_MS)
+            }
+
+            // --- Compute and print summary statistics ---
+            // Min/max/mean give a quick overview of load stability and
+            // reveal any voltage sag under load.
+            println("\n=== Summary ===")
+            println("%-12s  %-10s  %-10s  %-10s".format("", "V_bus (V)", "I (A)", "P (W)"))
+            println("%-12s  %-10.3f  %-10.4f  %-10.4f".format(
+                "min", voltages.min(), currents.min(), powers.min()))
+            println("%-12s  %-10.3f  %-10.4f  %-10.4f".format(
+                "max", voltages.max(), currents.max(), powers.max()))
+            println("%-12s  %-10.3f  %-10.4f  %-10.4f".format(
+                "mean", voltages.average(), currents.average(), powers.average()))
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+}

--- a/jvm/examples/kotlin/power/ina219/Minimal.kt
+++ b/jvm/examples/kotlin/power/ina219/Minimal.kt
@@ -1,0 +1,30 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina219Minimal
+
+fun main() {
+    val pi4j = Pi4J.newAutoContext()                                   // initialise Pi4J, () → Context
+    try {
+        I2CTransport(pi4j, 1, 0x40).use { transport ->                // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+            val ina = Ina219Minimal(transport)                         // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina219Minimal
+
+            while (true) {
+                val v  = ina.voltage()       // read bus voltage, () → Double V
+                val vs = ina.shuntVoltage()  // read shunt voltage, () → Double V
+                val i  = ina.current()       // read current, () → Double A
+                val p  = ina.power()         // read power, () → Double W
+                println("V_bus=%.3f V  V_shunt=%.6f V  I=%.4f A  P=%.4f W".format(v, vs, i, p))
+                Thread.sleep(1000)
+            }
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+}

--- a/jvm/examples/kotlin/power/ina226/Complete.kt
+++ b/jvm/examples/kotlin/power/ina226/Complete.kt
@@ -1,0 +1,68 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina226Full
+
+fun main() {
+    val pi4j = Pi4J.newAutoContext()                                    // initialise Pi4J, () → Context
+    try {
+        I2CTransport(pi4j, 1, 0x40).use { transport ->                 // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+
+            val ina = Ina226Full(transport, 0.1, 2.0)                  // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina226Full
+
+            val v  = ina.voltage()                                      // read bus voltage, () → Double V
+                                                                        // unsigned 16-bit, 1.25 mV per LSB
+            val vs = ina.shuntVoltage()                                 // read shunt voltage, () → Double V
+                                                                        // signed 16-bit, 2.5 µV per LSB
+            val c  = ina.current()                                      // read current, () → Double A
+                                                                        // signed, Current_LSB = maxCurrent / 32768 per bit
+            val p  = ina.power()                                        // read power, () → Double W
+                                                                        // unsigned, power = 25 × Current_LSB × raw
+            println("V=%.3f V  Vshunt=%.6f V  I=%.4f A  P=%.4f W".format(v, vs, c, p))
+
+            ina.configure(Ina226Full.AVG_128, Ina226Full.CT_1100US,    // configure ADC, (avg=4, vbusCt=4, vshCt=4, mode=7) → Unit
+                          Ina226Full.CT_1100US, Ina226Full.MODE_SHUNT_BUS_CONT)
+                                                                        // sets 128-sample averaging and 1.1 ms conversion times; continuous mode
+
+            val ready = ina.conversionReady()                           // check conversion ready flag, () → Boolean
+                                                                        // reads CVRF bit (bit 3) from Mask/Enable register
+            println("Conversion ready: $ready")
+
+            val ovf = ina.overflow()                                    // check math overflow flag, () → Boolean
+                                                                        // reads OVF bit (bit 2) from Mask/Enable register
+            println("Overflow: $ovf")
+
+            ina.setAlert(Ina226Full.POL, 1.0)                          // set power over-limit alert to 1 W, (function=POL, limit=1.0 W) → Unit
+                                                                        // writes function to Mask/Enable, limit raw = int(1.0 / (25 × Current_LSB)) to Alert Limit
+
+            val flags = ina.alertFlags()                                // read alert flags, () → Int
+                                                                        // reads Mask/Enable register; reading also clears the alert latch
+            println("Alert flags: 0x%04X".format(flags))
+
+            val mfrId = ina.manufacturerId()                            // read manufacturer ID, () → Int
+                                                                        // should return 0x5449 ("TI")
+            val dieId = ina.dieId()                                     // read die ID, () → Int
+                                                                        // should return 0x2260 for INA226
+            println("Manufacturer ID: 0x%04X  Die ID: 0x%04X".format(mfrId, dieId))
+
+            ina.shutdown()                                              // enter power-down mode, () → Unit
+                                                                        // sets MODE=000; previously active mode stored for wake()
+            Thread.sleep(100)
+
+            ina.wake()                                                  // restore previous operating mode, () → Unit
+                                                                        // writes previously stored mode bits back to Configuration register
+            Thread.sleep(10)
+
+            ina.reset()                                                 // reset chip and re-write calibration, () → Unit
+                                                                        // sets RST bit; chip returns to 0x4127; calibration re-written
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+}

--- a/jvm/examples/kotlin/power/ina226/Demo.kt
+++ b/jvm/examples/kotlin/power/ina226/Demo.kt
@@ -1,0 +1,77 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina226Full
+
+/**
+ * Power-supply monitoring demo: poll voltage, current, and power once per second
+ * for 10 seconds, track min/max/mean, and demonstrate a power over-limit alert.
+ *
+ * Between samples 4 and 5 the user is prompted to switch on a load so that the
+ * effect of load variation is visible in the statistics. The power over-limit
+ * alert is set to 1 W; alertFlags() is checked on every iteration.
+ */
+
+private const val SAMPLES     = 10
+private const val INTERVAL_MS = 1000L
+private const val ALERT_POWER = 1.0  // W
+
+fun main() {
+    val pi4j = Pi4J.newAutoContext()                                    // initialise Pi4J, () → Context
+    try {
+        I2CTransport(pi4j, 1, 0x40).use { transport ->                 // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+            val ina = Ina226Full(transport, 0.1, 2.0)                  // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina226Full
+
+            // --- Configure for noise-sensitive power rail monitoring ---
+            // 128-sample averaging suppresses switching noise on a noisy supply;
+            // continuous mode avoids re-triggering overhead between measurements.
+            ina.configure(Ina226Full.AVG_128, Ina226Full.CT_1100US,    // configure ADC, (avg=4, vbusCt=4, vshCt=4, mode=7) → Unit
+                          Ina226Full.CT_1100US, Ina226Full.MODE_SHUNT_BUS_CONT)
+
+            // --- Arm a power over-limit alert at 1 W ---
+            // The POL function asserts the ALERT pin and sets the OVF latch when
+            // the calculated power register exceeds the threshold. We poll alertFlags()
+            // on each iteration instead of wiring a GPIO interrupt.
+            ina.setAlert(Ina226Full.POL, ALERT_POWER)                  // set power over-limit alert, (function=POL, limit=1.0 W) → Unit
+
+            var minV = Double.MAX_VALUE; var maxV = -Double.MAX_VALUE; var sumV = 0.0
+            var minI = Double.MAX_VALUE; var maxI = -Double.MAX_VALUE; var sumI = 0.0
+            var minP = Double.MAX_VALUE; var maxP = -Double.MAX_VALUE; var sumP = 0.0
+
+            for (i in 0 until SAMPLES) {
+                if (i == 4) println("Switch on load now...")
+
+                val v = ina.voltage()      // read bus voltage, () → Double V
+                val c = ina.current()      // read current, () → Double A
+                val p = ina.power()        // read power, () → Double W
+
+                val alertRaw = ina.alertFlags()  // read alert flags (clears latch), () → Int
+                val alert = (alertRaw and Ina226Full.POL) != 0
+                println("Sample %2d: V=%.3f V  I=%.4f A  P=%.4f W%s".format(
+                    i + 1, v, c, p, if (alert) "  [ALERT: power over limit]" else ""))
+
+                if (v < minV) minV = v; if (v > maxV) maxV = v; sumV += v
+                if (c < minI) minI = c; if (c > maxI) maxI = c; sumI += c
+                if (p < minP) minP = p; if (p > maxP) maxP = p; sumP += p
+
+                Thread.sleep(INTERVAL_MS)
+            }
+
+            // --- Print summary statistics ---
+            // Min/max/mean over the 10-second window gives a compact view of
+            // supply stability and load variation.
+            println()
+            println("Bus voltage  — min=%.3f V   max=%.3f V   mean=%.3f V".format(minV, maxV, sumV / SAMPLES))
+            println("Current      — min=%.4f A  max=%.4f A  mean=%.4f A".format(minI, maxI, sumI / SAMPLES))
+            println("Power        — min=%.4f W  max=%.4f W  mean=%.4f W".format(minP, maxP, sumP / SAMPLES))
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+}

--- a/jvm/examples/kotlin/power/ina226/Minimal.kt
+++ b/jvm/examples/kotlin/power/ina226/Minimal.kt
@@ -1,0 +1,30 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina226Minimal
+
+fun main() {
+    val pi4j = Pi4J.newAutoContext()                                    // initialise Pi4J, () → Context
+    try {
+        I2CTransport(pi4j, 1, 0x40).use { transport ->                 // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+            val ina = Ina226Minimal(transport, 0.1, 2.0)               // construct driver, (transport, rShunt=0.1 Ω, maxCurrent=2.0 A) → Ina226Minimal
+
+            repeat(10) {
+                val v  = ina.voltage()       // read bus voltage, () → Double V
+                val vs = ina.shuntVoltage()  // read shunt voltage, () → Double V
+                val c  = ina.current()       // read current, () → Double A
+                val p  = ina.power()         // read power, () → Double W
+                println("V=%.3f V  Vshunt=%.6f V  I=%.4f A  P=%.4f W".format(v, vs, c, p))
+                Thread.sleep(1000)
+            }
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+}

--- a/jvm/examples/kotlin/power/ina3221/Complete.kt
+++ b/jvm/examples/kotlin/power/ina3221/Complete.kt
@@ -1,0 +1,90 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina3221Full
+
+fun main() {
+    val pi4j = Pi4J.newAutoContext()                                    // initialise Pi4J, () → Context
+    try {
+        I2CTransport(pi4j, 1, 0x40).use { transport ->                 // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+            val ina = Ina3221Full(transport)                            // construct driver (0.1 Ω shunt all channels), (transport) → Ina3221Full
+
+            ina.configure(1, 4, 4, Ina3221Full.MODE_SHUNT_BUS_CONT)    // configure averaging and conversion times, (avg=0–7, vbusCt=0–7, vshCt=0–7, mode=0–7) → Unit
+                                                                        // avg=1 means 4-sample average; vbusCt/vshCt=4 means 1.1 ms each
+
+            for (ch in 1..3) {
+                ina.enableChannel(ch, true)                             // enable a channel, (channel=1–3, enabled) → Unit
+                                                                        // sets the CH<n>en bit in the configuration register
+                val en = ina.channelEnabled(ch)                         // read channel enable state, (channel=1–3) → Boolean
+                                                                        // true when the CH<n>en bit is set
+                println("CH$ch enabled: $en")
+            }
+
+            for (ch in 1..3) {
+                val v  = ina.voltage(ch)                                // read bus voltage, (channel=1–3) → Double V
+                                                                        // left-aligned 12-bit unsigned, 8 mV LSB
+                val sv = ina.shuntVoltage(ch)                           // read shunt voltage, (channel=1–3) → Double V
+                                                                        // left-aligned 13-bit signed, 40 µV LSB
+                val i  = ina.current(ch)                                // compute current from shunt voltage, (channel=1–3) → Double A
+                                                                        // current = shuntVoltage / rShunt
+                val p  = ina.power(ch)                                  // compute power, (channel=1–3) → Double W
+                                                                        // power = busVoltage × current
+                println("CH$ch: ${"%.3f".format(v)} V  ${"%.6f".format(sv)} V_shunt  ${"%.4f".format(i)} A  ${"%.4f".format(p)} W")
+            }
+
+            val cvrf = ina.conversionReady()                            // read conversion-ready flag, () → Boolean
+                                                                        // CVRF bit (bit 0) of Mask/Enable; set after each full conversion
+            println("Conversion ready: $cvrf")
+
+            ina.setCriticalAlert(1, 0.05)                               // set critical alert on channel 1, (channel=1–3, limitV) → Unit
+                                                                        // alert fires when |shunt voltage| exceeds this threshold
+            ina.setWarningAlert(1, 0.04)                                // set warning alert on channel 1, (channel=1–3, limitV) → Unit
+                                                                        // alert fires when |shunt voltage| exceeds this threshold
+            ina.setCriticalAlert(2, 0.05)                               // set critical alert on channel 2, (channel=1–3, limitV) → Unit
+            ina.setWarningAlert(2, 0.04)                                // set warning alert on channel 2, (channel=1–3, limitV) → Unit
+            ina.setCriticalAlert(3, 0.05)                               // set critical alert on channel 3, (channel=1–3, limitV) → Unit
+            ina.setWarningAlert(3, 0.04)                                // set warning alert on channel 3, (channel=1–3, limitV) → Unit
+
+            ina.setPowerValidLimits(5.5, 4.5)                           // set power-valid thresholds, (upperV, lowerV) → Unit
+                                                                        // PVF bit set when all enabled bus voltages are within [lowerV, upperV]
+            val pv = ina.powerValid()                                    // read power-valid flag, () → Boolean
+                                                                        // PVF bit (bit 2) of Mask/Enable register
+            println("Power valid: $pv")
+
+            ina.setSummationChannels(intArrayOf(1, 2, 3), 0.1)          // enable summation for all channels with limit, (channels, limitV) → Unit
+                                                                        // sets SCC bits in Mask/Enable and writes the sum limit register
+            val sumV = ina.summationValue()                             // read shunt-voltage sum, () → Double V
+                                                                        // 14-bit signed, left-aligned by 1; LSB = 20 µV
+            println("Shunt voltage sum: ${"%.6f".format(sumV)} V")
+
+            val flags = ina.alertFlags()                                // read and clear alert flags, () → Int
+                                                                        // reads Mask/Enable; clears latched flags; inspect against CF1/WF1/PVF etc.
+            println("Alert flags: 0x%04X".format(flags))
+
+            val mfr = ina.manufacturerId()                              // read manufacturer ID, () → Int
+                                                                        // expected 0x5449 ("TI")
+            val die = ina.dieId()                                       // read die ID, () → Int
+                                                                        // expected 0x3220
+            println("Manufacturer ID: 0x%04X  Die ID: 0x%04X".format(mfr, die))
+
+            ina.shutdown()                                               // enter power-down mode (MODE=000), () → Unit
+                                                                        // saves current MODE so wake() can restore it
+            Thread.sleep(100)
+
+            ina.wake()                                                   // restore saved operating mode, () → Unit
+                                                                        // writes previously saved MODE bits back into config register
+            Thread.sleep(100)
+
+            ina.reset()                                                  // software reset via RST bit, then restore saved mode, () → Unit
+                                                                        // resets all registers to hardware defaults, then writes saved MODE back
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+}

--- a/jvm/examples/kotlin/power/ina3221/Demo.kt
+++ b/jvm/examples/kotlin/power/ina3221/Demo.kt
@@ -1,0 +1,113 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina3221Full
+
+/**
+ * Three-rail power monitor demo.
+ *
+ * Wire the INA3221 across three power rails (e.g. 3.3 V, 5 V, 12 V) each with
+ * a 0.1 Ω shunt. The script polls all three channels once per second for 30 s,
+ * printing a tabular row per second. At t=10 s it arms critical alerts at 1.5×
+ * the observed current draw on each channel. At t=20 s it enables summation
+ * across all three channels. After the run it dumps the final alert flags.
+ */
+
+private const val POLL_S    = 30
+private const val R_SHUNT   = 0.1   // Ω
+private const val ALERT_MUL = 1.5
+
+fun main() {
+    val pi4j = Pi4J.newAutoContext()                                    // initialise Pi4J, () → Context
+    try {
+        I2CTransport(pi4j, 1, 0x40).use { transport ->                 // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+
+            // --- Construct driver with 0.1 Ω shunt on all rails ---
+            // Using a common shunt value simplifies wiring; per-channel values can
+            // be supplied via the DoubleArray constructor if rails differ.
+            val ina = Ina3221Full(transport, R_SHUNT)                   // construct driver, (transport, rShunt=0.1 Ω) → Ina3221Full
+
+            // --- Configure: 4-sample averaging, 1.1 ms conversions, continuous mode ---
+            // 4-sample averaging reduces noise on switching-mode supplies without
+            // significantly increasing the effective sample interval (~10 ms total).
+            ina.configure(1, 4, 4, Ina3221Full.MODE_SHUNT_BUS_CONT)    // configure ADC, (avg=1→4 samples, vbusCt=4, vshCt=4, mode=7) → Unit
+
+            val firstI = doubleArrayOf(0.0, 0.0, 0.0)
+            var alertsArmed = false
+            var summationEnabled = false
+
+            println("%-5s  %-24s  %-24s  %-24s".format(
+                "t(s)", "--- CH1 V/A/W ---", "--- CH2 V/A/W ---", "--- CH3 V/A/W ---"))
+            println("-".repeat(85))
+
+            for (t in 0 until POLL_S) {
+
+                // --- Poll all three channels ---
+                // Each read is two I²C transactions (bus + shunt register). Current
+                // and power are derived in software — no hardware division needed.
+                val v = DoubleArray(4)
+                val i = DoubleArray(4)
+                val p = DoubleArray(4)
+                for (ch in 1..3) {
+                    v[ch] = ina.voltage(ch)                             // read bus voltage, (channel=1–3) → Double V
+                    i[ch] = ina.current(ch)                             // compute current, (channel=1–3) → Double A
+                    p[ch] = ina.power(ch)                               // compute power, (channel=1–3) → Double W
+                }
+
+                if (t == 0) {
+                    for (ch in 1..3) firstI[ch - 1] = i[ch]
+                }
+
+                println("%-5d  %6.3f V %6.3f A %6.3f W  %6.3f V %6.3f A %6.3f W  %6.3f V %6.3f A %6.3f W".format(
+                    t,
+                    v[1], i[1], p[1],
+                    v[2], i[2], p[2],
+                    v[3], i[3], p[3]))
+
+                // --- At t=10 s: arm critical alerts at 1.5× initial draw ---
+                // Setting the limit as a shunt voltage: limit_V = current × rShunt × 1.5.
+                // This lets the hardware flag transient spikes without software polling.
+                if (t == 10 && !alertsArmed) {
+                    for (ch in 1..3) {
+                        var limit = Math.abs(firstI[ch - 1]) * R_SHUNT * ALERT_MUL
+                        if (limit < 40e-6) limit = 40e-6
+                        ina.setCriticalAlert(ch, limit)                 // set critical alert, (channel=1–3, limitV) → Unit
+                    }
+                    println("  [t=10] Critical alerts armed at 1.5x initial draw")
+                    alertsArmed = true
+                }
+
+                // --- At t=20 s: enable summation across all three channels ---
+                // Summation lets the hardware accumulate shunt voltages; the sum
+                // register gives total power-bus current in a single read.
+                if (t == 20 && !summationEnabled) {
+                    var sumLimit = (Math.abs(firstI[0]) + Math.abs(firstI[1]) + Math.abs(firstI[2])) *
+                                   R_SHUNT * ALERT_MUL
+                    if (sumLimit < 40e-6) sumLimit = 40e-6
+                    ina.setSummationChannels(intArrayOf(1, 2, 3), sumLimit) // enable all-channel summation, (channels, limitV) → Unit
+                    println("  [t=20] Summation enabled for channels 1+2+3")
+                    summationEnabled = true
+                }
+
+                Thread.sleep(1000)
+            }
+
+            // --- Final alert flag dump ---
+            // Reading Mask/Enable clears latched flags; inspect individual bits.
+            val flags = ina.alertFlags()                                // read and clear alert flags, () → Int
+            println("\nFinal alert flags: 0x%04X".format(flags))
+            if (flags and Ina3221Full.CF1 != 0) println("  Critical alert fired on CH1")
+            if (flags and Ina3221Full.CF2 != 0) println("  Critical alert fired on CH2")
+            if (flags and Ina3221Full.CF3 != 0) println("  Critical alert fired on CH3")
+            if (flags and Ina3221Full.SF  != 0) println("  Summation alert fired")
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+}

--- a/jvm/examples/kotlin/power/ina3221/Minimal.kt
+++ b/jvm/examples/kotlin/power/ina3221/Minimal.kt
@@ -1,0 +1,32 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina3221Minimal
+
+fun main() {
+    val pi4j = Pi4J.newAutoContext()                                    // initialise Pi4J, () → Context
+    try {
+        I2CTransport(pi4j, 1, 0x40).use { transport ->                 // open I²C bus 1, device 0x40, (bus, address) → I2CTransport
+            val ina = Ina3221Minimal(transport)                         // construct driver (0.1 Ω shunt all channels), (transport) → Ina3221Minimal
+
+            while (true) {
+                for (ch in 1..3) {
+                    val v = ina.voltage(ch)                             // read bus voltage, (channel=1–3) → Double V
+                    val i = ina.current(ch)                             // compute current via shunt, (channel=1–3) → Double A
+                    val p = ina.power(ch)                               // compute power, (channel=1–3) → Double W
+                    println("CH$ch: ${"%.3f".format(v)} V  ${"%.4f".format(i)} A  ${"%.4f".format(p)} W")
+                }
+                println("---")
+                Thread.sleep(1000)
+            }
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+}

--- a/jvm/examples/kotlin/pressure/bmp180/Complete.kt
+++ b/jvm/examples/kotlin/pressure/bmp180/Complete.kt
@@ -1,0 +1,61 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.pressure.Bmp180Full
+
+fun main() {
+    val pi4j = Pi4J.newAutoContext()                                    // initialise Pi4J, () → Context
+    try {
+        I2CTransport(pi4j, 1, 0x77).use { transport ->                 // open I²C bus 1, device 0x77, (bus, address=0x77) → I2CTransport
+            val sensor = Bmp180Full(transport)                          // construct driver, verifies chip ID and loads calibration, (transport) → Bmp180Full
+
+            val id = sensor.chipId()                                    // read chip ID register 0xD0, () → Int
+                                                                        // returns 0x55 for BMP180; useful for confirming the device is present
+            println("chip ID: 0x%02X".format(id))
+
+            val oss = sensor.oversampling()                             // read current OSS setting, () → Int
+                                                                        // 0 = ultra-low-power (default), 1 = standard, 2 = high-res, 3 = ultra-high-res
+            println("oversampling: $oss")
+
+            sensor.setOversampling(Bmp180Full.OSS_HIGH_RES)            // set oversampling to high-resolution mode, (oss=0–3) → Unit
+                                                                        // OSS = 2: 4 internal samples averaged, ~13.5 ms conversion time
+
+            val t = sensor.temperature()                                // read temperature, () → Double °C
+                                                                        // triggers a 5 ms ADC conversion, applies Bosch integer compensation
+            println("temperature: %.2f °C".format(t))
+
+            val p = sensor.pressure()                                   // read pressure, () → Double hPa
+                                                                        // re-reads temperature to refresh B5, then triggers pressure ADC
+            println("pressure: %.2f hPa".format(p))
+
+            val alt = sensor.altitude()                                 // compute altitude using default sea-level pressure 1013.25 hPa, () → Double m
+                                                                        // applies barometric formula: 44330 × (1 − (p/1013.25)^(1/5.255))
+            println("altitude: %.1f m".format(alt))
+
+            val altRef = sensor.altitude(1013.00)                      // compute altitude with custom sea-level pressure, (seaLevelHpa=1013.25 hPa) → Double m
+                                                                        // use local QNH for accurate terrain altitude
+            println("altitude (QNH 1013.00): %.1f m".format(altRef))
+
+            val slp = sensor.seaLevelPressure(50.0)                    // back-calculate sea-level pressure at known altitude, (altitudeM=0.0 m) → Double hPa
+                                                                        // reduces station pressure to MSL using the barometric formula inverse
+            println("sea-level pressure at 50 m: %.2f hPa".format(slp))
+
+            sensor.reset()                                              // soft-reset the chip and reload calibration, () → Unit
+                                                                        // writes 0xB6 to 0xE0, waits 15 ms, then re-reads calibration EEPROM
+
+            sensor.setOversampling(Bmp180Full.OSS_ULP)                 // restore ultra-low-power mode, (oss=0–3) → Unit
+                                                                        // OSS = 0: single sample, ~4.5 ms, lowest power consumption
+
+            println("oversampling after reset: ${sensor.oversampling()}") // read current OSS setting, () → Int
+                                                                           // reset() restores chip but local field retains 0 since it was set after construction
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+}

--- a/jvm/examples/kotlin/pressure/bmp180/Demo.kt
+++ b/jvm/examples/kotlin/pressure/bmp180/Demo.kt
@@ -1,0 +1,90 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.pressure.Bmp180Full
+import kotlin.math.abs
+
+/**
+ * Pocket altimeter: 60-second run at 1 Hz in ULP mode.
+ *
+ * The first reading establishes the sea-level reference so altitude starts at 0.
+ * Each subsequent reading reports temperature, pressure, altitude, and vertical
+ * displacement (in cm) relative to the reference. After the run, prints
+ * min/max/mean for all three quantities.
+ */
+
+private const val SAMPLES     = 60
+private const val INTERVAL_MS = 1000L
+
+fun main() {
+    val pi4j = Pi4J.newAutoContext()                               // initialise Pi4J, () → Context
+    try {
+        I2CTransport(pi4j, 1, 0x77).use { transport ->            // open I²C bus 1, device 0x77 (fixed address), (bus, address=0x77) → I2CTransport
+            val sensor = Bmp180Full(transport)                     // construct driver, verifies chip ID, reads calibration, (transport) → Bmp180Full
+
+            // --- Configure for low-power continuous monitoring ---
+            // ULP mode (OSS = 0) minimises power draw (~3 µA RMS) and conversion time
+            // (~4.5 ms). For a pocket altimeter taking one sample per second the
+            // extra resolution of higher OSS is not needed; ULP resolves ~1 m.
+            sensor.setOversampling(Bmp180Full.OSS_ULP)             // set ultra-low-power mode, (oss=0–3) → Unit
+
+            // --- Take first reading to establish reference altitude ---
+            // The sea-level pressure derived from this reading anchors altitude = 0.
+            // Any subsequent change in pressure will appear as vertical displacement.
+            val firstPressure = sensor.pressure()                  // read pressure for reference, () → Double hPa
+            val seaLevel      = sensor.seaLevelPressure(0.0)      // derive sea-level pressure at altitude = 0, (altitudeM=0.0 m) → Double hPa
+            val firstTemp     = sensor.temperature()               // read temperature for reference, () → Double °C
+            val firstAlt      = sensor.altitude(seaLevel)         // compute altitude (should be ~0), (seaLevelHpa) → Double m
+
+            println("Reference: temperature=%.2f °C  pressure=%.2f hPa  altitude=%.1f m  (sea-level ref=%.2f hPa)"
+                .format(firstTemp, firstPressure, firstAlt, seaLevel))
+
+            val temps     = DoubleArray(SAMPLES)
+            val pressures = DoubleArray(SAMPLES)
+            val altitudes = DoubleArray(SAMPLES)
+
+            // --- 60-second sampling loop ---
+            // Each iteration reads temperature, pressure, and altitude; prints the
+            // current values plus vertical displacement from the reference position.
+            for (i in 0 until SAMPLES) {
+                val t   = sensor.temperature()                     // read temperature, () → Double °C
+                val p   = sensor.pressure()                        // read pressure, () → Double hPa
+                val alt = sensor.altitude(seaLevel)               // compute altitude relative to reference, (seaLevelHpa) → Double m
+                val dAlt = alt - firstAlt
+
+                temps[i]     = t
+                pressures[i] = p
+                altitudes[i] = alt
+
+                val direction = when {
+                    dAlt >  0.005 -> "up"
+                    dAlt < -0.005 -> "down"
+                    else          -> "level"
+                }
+                println("[%2d] temperature=%.2f °C  pressure=%.2f hPa  altitude=%.1f m  moved %s %.0f cm"
+                    .format(i + 1, t, p, alt, direction, abs(dAlt) * 100))
+
+                Thread.sleep(INTERVAL_MS)
+            }
+
+            // --- Print summary statistics ---
+            // After the run, report the full range and mean for each quantity so
+            // the user can see how much the environment changed during the session.
+            println("\n--- Summary ($SAMPLES samples) ---")
+            println("Temperature: min=%.2f °C  max=%.2f °C  mean=%.2f °C"
+                .format(temps.min(), temps.max(), temps.average()))
+            println("Pressure:    min=%.2f hPa  max=%.2f hPa  mean=%.2f hPa"
+                .format(pressures.min(), pressures.max(), pressures.average()))
+            println("Altitude:    min=%.1f m  max=%.1f m  mean=%.1f m"
+                .format(altitudes.min(), altitudes.max(), altitudes.average()))
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+}

--- a/jvm/examples/kotlin/pressure/bmp180/Minimal.kt
+++ b/jvm/examples/kotlin/pressure/bmp180/Minimal.kt
@@ -1,0 +1,28 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.pressure.Bmp180Minimal
+
+fun main() {
+    val pi4j = Pi4J.newAutoContext()                                // initialise Pi4J, () → Context
+    try {
+        I2CTransport(pi4j, 1, 0x77).use { transport ->             // open I²C bus 1, device 0x77, (bus, address=0x77) → I2CTransport
+            val sensor = Bmp180Minimal(transport)                   // construct driver, verifies chip ID and loads calibration, (transport) → Bmp180Minimal
+
+            while (true) {
+                val t = sensor.temperature()                        // read temperature, () → Double °C
+                val p = sensor.pressure()                           // read pressure, () → Double hPa
+                println("temperature=%.2f °C  pressure=%.2f hPa".format(t, p))
+                Thread.sleep(1000)
+            }
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+}

--- a/jvm/periph-groovy/pom.xml
+++ b/jvm/periph-groovy/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it.uhde</groupId>
+        <artifactId>periph</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>periph-groovy</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>it.uhde</groupId>
+            <artifactId>periph-transport</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>${groovy.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compileTests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/adc_dac/Mcp4725Full.groovy
+++ b/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/adc_dac/Mcp4725Full.groovy
@@ -1,0 +1,148 @@
+package it.uhde.periph.chips.adc_dac
+
+import groovy.transform.CompileStatic
+import groovy.transform.Immutable
+import it.uhde.periph.transport.Transport
+
+/**
+ * Read-back state of the MCP4725.
+ *
+ * @param code current DAC register value (0–4095)
+ * @param voltageFraction DAC register value as fraction of V_DD (code / 4095.0)
+ * @param powerDown current power-down mode of the DAC register (0–3)
+ * @param eepromCode EEPROM-stored DAC value (0–4095)
+ * @param eepromPowerDown EEPROM-stored power-down mode (0–3)
+ * @param eepromReady true when EEPROM write is complete (RDY/BSY = 1)
+ */
+@Immutable
+class ReadResult {
+    int code
+    double voltageFraction
+    int powerDown
+    int eepromCode
+    int eepromPowerDown
+    boolean eepromReady
+}
+
+/**
+ * MCP4725 — full driver. Extends {@link Mcp4725Minimal} with EEPROM persistence,
+ * power-down control, read-back, and General Call commands (reset / wake-up).
+ *
+ * <p>General Call commands (reset, wakeUp) require a second transport bound to
+ * address 0x00. Pass {@code null} to disable those methods.
+ *
+ * <h2>EEPROM write timing</h2>
+ * The EEPROM write takes up to 50 ms. New write commands are silently ignored
+ * while RDY/BSY is low. Poll {@link #isEepromReady()} or wait 50 ms before
+ * issuing a second EEPROM write.
+ */
+@CompileStatic
+class Mcp4725Full extends Mcp4725Minimal {
+
+    private final Transport generalCall
+
+    /**
+     * Construct the full driver.
+     *
+     * @param transport   I²C transport bound to the MCP4725 device address
+     * @param generalCall I²C transport bound to address 0x00 for General Call
+     *                    commands, or {@code null} to disable reset/wakeUp
+     */
+    Mcp4725Full(Transport transport, Transport generalCall) {
+        super(transport)
+        this.generalCall = generalCall
+    }
+
+    /**
+     * Write fraction to both the DAC register and EEPROM.
+     *
+     * @param fraction target output level, 0.0–1.0
+     */
+    void setVoltageEeprom(double fraction) {
+        fraction = Math.max(0.0, Math.min(1.0, fraction))
+        setRawEeprom((int) Math.round(fraction * 4095))
+    }
+
+    /**
+     * Write a raw 12-bit code to both the DAC register and EEPROM.
+     *
+     * <p>The value persists across power cycles. Wait up to 50 ms before
+     * issuing another EEPROM write.
+     *
+     * @param code 12-bit DAC value (0–4095)
+     */
+    void setRawEeprom(int code) {
+        code = Math.max(0, Math.min(4095, code))
+        lastCode = code
+        // Write DAC + EEPROM: C2=0 C1=1 C0=1 → byte1=0x60 (normal mode)
+        transport.write([0x60 as byte, (byte) ((code >> 4) & 0xFF), (byte) ((code << 4) & 0xF0)] as byte[])
+    }
+
+    /**
+     * Read the current state of the device (5-byte read response).
+     *
+     * @return snapshot of DAC register, EEPROM, power-down, and ready flag
+     */
+    ReadResult read() {
+        byte[] b = transport.read(5)
+        boolean eepromReady = (b[0] & 0x80) != 0
+        int powerDown       = (b[0] >> 2) & 0x03
+        int code            = ((b[1] & 0xFF) << 4) | ((b[2] & 0xFF) >> 4)
+        int eepromPD        = (b[3] >> 5) & 0x03
+        int eepromCode      = ((b[3] & 0x0F) << 8) | (b[4] & 0xFF)
+        new ReadResult(code, code / 4095.0, powerDown, eepromCode, eepromPD, eepromReady)
+    }
+
+    /**
+     * Enter or exit power-down mode using a Fast Write.
+     *
+     * <p>The last-written DAC code is preserved so the output resumes at the same
+     * level when mode 0 is selected again.
+     *
+     * @param mode 0 = normal, 1 = 1 kΩ to GND, 2 = 100 kΩ to GND, 3 = 500 kΩ to GND
+     */
+    void setPowerDown(int mode) {
+        mode = Math.max(0, Math.min(3, mode))
+        // Fast Write with PD bits set: [0 0 PD1 PD0 D11-D8] [D7-D0]
+        transport.write([(byte) (((mode & 0x03) << 4) | ((lastCode >> 8) & 0x0F)), (byte) (lastCode & 0xFF)] as byte[])
+    }
+
+    /**
+     * Send General Call Wake-Up (address 0x00, command 0x09).
+     *
+     * <p>Clears the power-down bits in the DAC register of all MCP47xx devices
+     * on the bus that support General Call.
+     *
+     * @throws IllegalStateException if no General Call transport was provided
+     */
+    void wakeUp() {
+        requireGeneralCall().write([0x09 as byte] as byte[])
+    }
+
+    /**
+     * Send General Call Reset (address 0x00, command 0x06).
+     *
+     * <p>Triggers an internal power-on reset on all MCP47xx devices on the bus
+     * that support General Call, reloading EEPROM contents into the DAC register.
+     *
+     * @throws IllegalStateException if no General Call transport was provided
+     */
+    void reset() {
+        requireGeneralCall().write([0x06 as byte] as byte[])
+    }
+
+    /**
+     * Read the RDY/BSY bit.
+     *
+     * @return true when the EEPROM write is complete
+     */
+    boolean isEepromReady() {
+        (transport.read(1)[0] & 0x80) != 0
+    }
+
+    private Transport requireGeneralCall() {
+        if (generalCall == null)
+            throw new IllegalStateException('General Call transport not configured')
+        generalCall
+    }
+}

--- a/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/adc_dac/Mcp4725Minimal.groovy
+++ b/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/adc_dac/Mcp4725Minimal.groovy
@@ -1,0 +1,57 @@
+package it.uhde.periph.chips.adc_dac
+
+import groovy.transform.CompileStatic
+import it.uhde.periph.transport.Transport
+
+/**
+ * MCP4725 — 12-bit single-channel DAC with I²C interface (minimal driver).
+ *
+ * <p>Outputs a voltage from 0 V to V_DD by writing a 12-bit code over I²C.
+ * Only the DAC register is updated; the EEPROM is never touched by this class.
+ * All writes use the Fast Write command (2 bytes).
+ *
+ * <p>Default I²C address: 0x60 (A0 pin = GND), 0x61 (A0 pin = VDD).
+ */
+@CompileStatic
+class Mcp4725Minimal {
+
+    protected final Transport transport
+    /** Last code written; used by subclass setPowerDown to preserve the output level. */
+    protected int lastCode = 0
+
+    /**
+     * Construct the driver.
+     *
+     * @param transport I²C transport bound to the MCP4725 device address
+     */
+    Mcp4725Minimal(Transport transport) {
+        this.transport = transport
+    }
+
+    /**
+     * Set the DAC output as a fraction of V_DD using a Fast Write.
+     *
+     * <p>Fraction is clamped to [0.0, 1.0]. Maps to a 12-bit code via
+     * {@code code = round(fraction × 4095)}.
+     *
+     * @param fraction target output level, 0.0 = 0 V, 1.0 = V_DD
+     */
+    void setVoltage(double fraction) {
+        fraction = Math.max(0.0, Math.min(1.0, fraction))
+        setRaw((int) Math.round(fraction * 4095))
+    }
+
+    /**
+     * Set the DAC output to a raw 12-bit code using a Fast Write.
+     *
+     * <p>Code is clamped to [0, 4095]. Output voltage = V_DD × code / 4096.
+     *
+     * @param code 12-bit DAC value (0–4095)
+     */
+    void setRaw(int code) {
+        code = Math.max(0, Math.min(4095, code))
+        lastCode = code
+        // Fast Write: [0 0 PD1 PD0 D11-D8] [D7-D0]  — PD1=PD0=0 (normal mode)
+        transport.write([(byte) ((code >> 8) & 0x0F), (byte) (code & 0xFF)] as byte[])
+    }
+}

--- a/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina219Full.groovy
+++ b/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina219Full.groovy
@@ -1,0 +1,159 @@
+package it.uhde.periph.chips.power
+
+import groovy.transform.CompileStatic
+import it.uhde.periph.transport.Transport
+
+/**
+ * INA219 — full driver. Extends {@link Ina219Minimal} with ADC configuration,
+ * conversion-ready and overflow status, software reset, power-down, wake, and
+ * one-shot trigger.
+ *
+ * <h2>PGA constants</h2>
+ * {@link #PGA_1}, {@link #PGA_2}, {@link #PGA_4}, {@link #PGA_8}
+ *
+ * <h2>Bus range constants</h2>
+ * {@link #BRNG_16V}, {@link #BRNG_32V}
+ *
+ * <h2>ADC constants</h2>
+ * {@link #ADC_9BIT}–{@link #ADC_12BIT}, {@link #ADC_AVG_2}–{@link #ADC_AVG_128}
+ *
+ * <h2>Mode constants</h2>
+ * {@link #MODE_POWERDOWN}–{@link #MODE_SHUNT_BUS_CONT}
+ */
+@CompileStatic
+class Ina219Full extends Ina219Minimal {
+
+    // PGA gain
+    static final int PGA_1 = 0
+    static final int PGA_2 = 1
+    static final int PGA_4 = 2
+    static final int PGA_8 = 3
+
+    // Bus voltage range
+    static final int BRNG_16V = 0
+    static final int BRNG_32V = 1
+
+    // ADC resolution / averaging
+    static final int ADC_9BIT    = 0
+    static final int ADC_10BIT   = 1
+    static final int ADC_11BIT   = 2
+    static final int ADC_12BIT   = 3
+    static final int ADC_AVG_2   = 9
+    static final int ADC_AVG_4   = 10
+    static final int ADC_AVG_8   = 11
+    static final int ADC_AVG_16  = 12
+    static final int ADC_AVG_32  = 13
+    static final int ADC_AVG_64  = 14
+    static final int ADC_AVG_128 = 15
+
+    // Operating modes
+    static final int MODE_POWERDOWN      = 0
+    static final int MODE_SHUNT_TRIG     = 1
+    static final int MODE_BUS_TRIG       = 2
+    static final int MODE_SHUNT_BUS_TRIG = 3
+    static final int MODE_ADC_OFF        = 4
+    static final int MODE_SHUNT_CONT     = 5
+    static final int MODE_BUS_CONT       = 6
+    static final int MODE_SHUNT_BUS_CONT = 7
+
+    /** Cached configuration register value (hardware default on power-on). */
+    private int config = 0x399F
+
+    /**
+     * Construct the full driver.
+     *
+     * @param transport  I²C transport bound to the INA219 device address
+     * @param rShunt     shunt resistance in Ω (default 0.1)
+     * @param maxCurrent maximum expected current in A (default 2.0)
+     */
+    Ina219Full(Transport transport, double rShunt = 0.1, double maxCurrent = 2.0) {
+        super(transport, rShunt, maxCurrent)
+    }
+
+    /**
+     * Write the configuration register.
+     *
+     * <p>All five fields are packed into the 16-bit register and written
+     * atomically. The value is cached so that {@link #reset()},
+     * {@link #shutdown()}, and {@link #wake()} can restore or modify it.
+     *
+     * @param brng bus voltage range (0 = 16 V, 1 = 32 V)
+     * @param pga  PGA gain (0–3)
+     * @param badc bus ADC resolution/averaging (0–3 or 9–15)
+     * @param sadc shunt ADC resolution/averaging (0–3 or 9–15)
+     * @param mode operating mode (0–7)
+     */
+    void configure(int brng, int pga, int badc, int sadc, int mode) {
+        config = ((brng & 0x01) << 13) |
+                 ((pga  & 0x03) << 11) |
+                 ((badc & 0x0F) << 7)  |
+                 ((sadc & 0x0F) << 3)  |
+                 (mode  & 0x07)
+        writeReg(REG_CONFIG, config)
+    }
+
+    /**
+     * Check whether a new conversion result is available.
+     *
+     * <p>Reads the Bus Voltage register and tests the CNVR bit (bit 1).
+     *
+     * @return {@code true} when a conversion is ready to be read
+     */
+    boolean conversionReady() {
+        (readReg(REG_BUS_V) & 0x02) != 0
+    }
+
+    /**
+     * Check the math overflow flag.
+     *
+     * <p>Reads the Bus Voltage register and tests the OVF bit (bit 0).
+     *
+     * @return {@code true} when an arithmetic overflow has occurred
+     */
+    boolean overflow() {
+        (readReg(REG_BUS_V) & 0x01) != 0
+    }
+
+    /**
+     * Perform a software reset and restore the configuration and calibration.
+     *
+     * <p>Sets the RST bit (bit 15), then re-writes the cached configuration and
+     * recomputes and re-writes the calibration register.
+     */
+    void reset() {
+        writeReg(REG_CONFIG, 0x8000)
+        writeReg(REG_CONFIG, config)
+        int cal = (int) (0.04096 / (currentLsb * rShunt)) & 0xFFFE
+        writeReg(REG_CALIBRATE, cal)
+    }
+
+    /**
+     * Enter power-down mode (MODE bits = 000).
+     *
+     * <p>Writes the cached configuration with the MODE field replaced by
+     * {@code MODE_POWERDOWN}. Call {@link #wake()} to exit.
+     */
+    void shutdown() {
+        writeReg(REG_CONFIG, (config & ~0x07) | MODE_POWERDOWN)
+    }
+
+    /**
+     * Exit power-down mode by restoring the cached configuration.
+     *
+     * <p>Re-writes the full cached configuration register, reinstating the
+     * original operating mode. Typically called after {@link #shutdown()}.
+     */
+    void wake() {
+        writeReg(REG_CONFIG, config)
+    }
+
+    /**
+     * Trigger a one-shot conversion by re-writing the configuration register.
+     *
+     * <p>In triggered modes re-writing the configuration register initiates a
+     * new single conversion. Harmless in continuous mode.
+     */
+    void trigger() {
+        writeReg(REG_CONFIG, config)
+    }
+}

--- a/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina219Minimal.groovy
+++ b/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina219Minimal.groovy
@@ -1,0 +1,130 @@
+package it.uhde.periph.chips.power
+
+import groovy.transform.CompileStatic
+import it.uhde.periph.transport.Transport
+
+/**
+ * INA219 — zero-drift, bidirectional current/power monitor with I²C interface
+ * (minimal driver).
+ *
+ * <p>Measures bus voltage (0–32 V), shunt voltage, current, and power via a
+ * sense resistor on the high or low side of the load. The calibration register
+ * is computed and written once during construction; the configuration register
+ * is left at its hardware reset value (0x399F: ±32 V bus, PGA /8, 12-bit,
+ * continuous shunt+bus mode).
+ *
+ * <p>Default I²C address: 0x40 (A1=GND, A0=GND).
+ */
+@CompileStatic
+class Ina219Minimal {
+
+    protected static final int REG_CONFIG    = 0x00
+    protected static final int REG_SHUNT_V   = 0x01
+    protected static final int REG_BUS_V     = 0x02
+    protected static final int REG_POWER     = 0x03
+    protected static final int REG_CURRENT   = 0x04
+    protected static final int REG_CALIBRATE = 0x05
+
+    protected final Transport transport
+    /** Shunt resistance in Ω — retained for calibration register recalculation. */
+    protected final double rShunt
+    /** Current register LSB in A/LSB. */
+    protected final double currentLsb
+    /** Power register LSB in W/LSB (= 20 × currentLsb). */
+    protected final double powerLsb
+
+    /**
+     * Construct the driver and program the calibration register.
+     *
+     * @param transport  I²C transport bound to the INA219 device address
+     * @param rShunt     shunt resistance in Ω (default 0.1)
+     * @param maxCurrent maximum expected current in A (default 2.0)
+     */
+    Ina219Minimal(Transport transport, double rShunt = 0.1, double maxCurrent = 2.0) {
+        this.transport  = transport
+        this.rShunt     = rShunt
+        this.currentLsb = maxCurrent / 32768.0
+        this.powerLsb   = 20.0 * currentLsb
+        int cal = (int) (0.04096 / (currentLsb * rShunt)) & 0xFFFE
+        writeReg(REG_CALIBRATE, cal)
+    }
+
+    /**
+     * Read the bus voltage.
+     *
+     * <p>Reads the Bus Voltage register (0x02), right-shifts by 3, and
+     * multiplies by the 4 mV LSB. Range: 0–32 V.
+     *
+     * @return bus voltage in V
+     */
+    double voltage() {
+        int raw = readReg(REG_BUS_V)
+        ((raw >> 3) & 0x1FFF) * 4e-3
+    }
+
+    /**
+     * Read the shunt (differential) voltage.
+     *
+     * <p>Reads the Shunt Voltage register (0x01) as a signed 16-bit value and
+     * multiplies by the 10 µV LSB.
+     *
+     * @return shunt voltage in V (negative for reverse current flow)
+     */
+    double shuntVoltage() {
+        int raw = readReg(REG_SHUNT_V)
+        int signed = raw > 32767 ? raw - 65536 : raw
+        signed * 10e-6
+    }
+
+    /**
+     * Read the current through the shunt resistor.
+     *
+     * <p>Reads the Current register (0x04) as a signed 16-bit value and
+     * multiplies by the current LSB computed during construction.
+     *
+     * @return current in A (negative for reverse flow)
+     */
+    double current() {
+        int raw = readReg(REG_CURRENT)
+        int signed = raw > 32767 ? raw - 65536 : raw
+        signed * currentLsb
+    }
+
+    /**
+     * Read the calculated power.
+     *
+     * <p>Reads the Power register (0x03) as an unsigned 16-bit value and
+     * multiplies by the power LSB (= 20 × current LSB).
+     *
+     * @return power in W (always non-negative)
+     */
+    double power() {
+        int raw = readReg(REG_POWER)
+        (raw & 0xFFFF) * powerLsb
+    }
+
+    // -------------------------------------------------------------------------
+    // Protected register I/O helpers (shared with Ina219Full)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Read a 16-bit big-endian register.
+     *
+     * @param reg register address (0x00–0x05)
+     * @return raw unsigned 16-bit value
+     */
+    protected int readReg(int reg) {
+        byte[] b = transport.writeRead([(byte) reg] as byte[], 2)
+        ((b[0] & 0xFF) << 8) | (b[1] & 0xFF)
+    }
+
+    /**
+     * Write a 16-bit big-endian register.
+     *
+     * @param reg register address (0x00–0x05)
+     * @param val 16-bit value to write
+     */
+    protected void writeReg(int reg, int val) {
+        transport.write([(byte) reg, (byte) ((val >> 8) & 0xFF), (byte) (val & 0xFF)] as byte[])
+    }
+}

--- a/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina226Full.groovy
+++ b/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina226Full.groovy
@@ -1,0 +1,206 @@
+package it.uhde.periph.chips.power
+
+import groovy.transform.CompileStatic
+import it.uhde.periph.transport.Transport
+
+/**
+ * INA226 — full driver. Extends {@link Ina226Minimal} with configuration,
+ * alert management, conversion-ready polling, reset, shutdown/wake, and
+ * device identification.
+ *
+ * <h2>Alert functions (bit positions in Mask/Enable register)</h2>
+ * <ul>
+ *   <li>{@link #SOL}  — shunt voltage over-limit (bit 15)</li>
+ *   <li>{@link #SUL}  — shunt voltage under-limit (bit 14)</li>
+ *   <li>{@link #BOL}  — bus voltage over-limit (bit 13)</li>
+ *   <li>{@link #BUL}  — bus voltage under-limit (bit 12)</li>
+ *   <li>{@link #POL}  — power over-limit (bit 11)</li>
+ *   <li>{@link #CNVR} — conversion ready (bit 10)</li>
+ * </ul>
+ */
+@CompileStatic
+class Ina226Full extends Ina226Minimal {
+
+    // --- Alert function constants ---
+    static final int SOL  = 32768
+    static final int SUL  = 16384
+    static final int BOL  = 8192
+    static final int BUL  = 4096
+    static final int POL  = 2048
+    static final int CNVR = 1024
+
+    // --- Averaging constants ---
+    static final int AVG_1    = 0
+    static final int AVG_4    = 1
+    static final int AVG_16   = 2
+    static final int AVG_64   = 3
+    static final int AVG_128  = 4
+    static final int AVG_256  = 5
+    static final int AVG_512  = 6
+    static final int AVG_1024 = 7
+
+    // --- Conversion time constants ---
+    static final int CT_140US  = 0
+    static final int CT_204US  = 1
+    static final int CT_332US  = 2
+    static final int CT_588US  = 3
+    static final int CT_1100US = 4
+    static final int CT_2116US = 5
+    static final int CT_4156US = 6
+    static final int CT_8244US = 7
+
+    // --- Mode constants ---
+    static final int MODE_POWERDOWN      = 0
+    static final int MODE_SHUNT_TRIG     = 1
+    static final int MODE_BUS_TRIG       = 2
+    static final int MODE_SHUNT_BUS_TRIG = 3
+    static final int MODE_SHUNT_CONT     = 5
+    static final int MODE_BUS_CONT       = 6
+    static final int MODE_SHUNT_BUS_CONT = 7
+
+    /**
+     * Construct the full driver with default shunt (0.1 Ω) and max current (2.0 A).
+     *
+     * @param transport I²C transport bound to the INA226 device address
+     */
+    Ina226Full(Transport transport) {
+        super(transport)
+    }
+
+    /**
+     * Construct the full driver.
+     *
+     * @param transport  I²C transport bound to the INA226 device address
+     * @param rShunt     shunt resistor value in Ω
+     * @param maxCurrent maximum expected current in A
+     */
+    Ina226Full(Transport transport, double rShunt, double maxCurrent) {
+        super(transport, rShunt, maxCurrent)
+    }
+
+    /**
+     * Write the Configuration register.
+     *
+     * @param avg    averaging count (0–7, use {@code AVG_*} constants)
+     * @param vbusCt bus voltage conversion time (0–7, use {@code CT_*} constants)
+     * @param vshCt  shunt voltage conversion time (0–7, use {@code CT_*} constants)
+     * @param mode   operating mode (0–7, use {@code MODE_*} constants)
+     */
+    void configure(int avg, int vbusCt, int vshCt, int mode) {
+        int cfg = ((avg    & 0x07) << 9) |
+                  ((vbusCt & 0x07) << 6) |
+                  ((vshCt  & 0x07) << 3) |
+                   (mode   & 0x07)
+        lastMode = mode & 0x07
+        writeReg(REG_CONFIG, cfg)
+    }
+
+    /**
+     * Check whether a conversion has completed (CVRF flag, bit 3 of Mask/Enable).
+     *
+     * @return true if a conversion is ready to be read
+     */
+    boolean conversionReady() {
+        (readReg(REG_MASK_EN) & 0x08) != 0
+    }
+
+    /**
+     * Check whether a math overflow occurred (OVF flag, bit 2 of Mask/Enable).
+     *
+     * @return true if an overflow has occurred
+     */
+    boolean overflow() {
+        (readReg(REG_MASK_EN) & 0x04) != 0
+    }
+
+    /**
+     * Configure an alert function and its threshold.
+     *
+     * <p>The raw limit is derived from the physical limit:
+     * <ul>
+     *   <li>SOL/SUL: raw = int(limit_V / 2.5e-6)</li>
+     *   <li>BOL/BUL: raw = int(limit_V / 1.25e-3)</li>
+     *   <li>POL:     raw = int(limit_W / (25 × Current_LSB))</li>
+     *   <li>CNVR:    limit is ignored</li>
+     * </ul>
+     *
+     * @param function alert function bitmask (e.g. {@code POL})
+     * @param limit    physical threshold (V for shunt/bus alerts, W for power alert)
+     */
+    void setAlert(int function, double limit) {
+        int raw
+        if (function == SOL || function == SUL) {
+            raw = (int) (limit / 2.5e-6d)
+        } else if (function == BOL || function == BUL) {
+            raw = (int) (limit / 1.25e-3d)
+        } else if (function == POL) {
+            raw = (int) (limit / (25.0d * currentLsb))
+        } else {
+            raw = 0
+        }
+        writeReg(REG_MASK_EN, function)
+        writeReg(REG_ALERT_LIM, raw & 0xFFFF)
+    }
+
+    /**
+     * Read the raw Mask/Enable register value.
+     *
+     * <p>Reading this register also clears the alert latch. The flags of interest
+     * are CVRF (bit 3) and OVF (bit 2); alert-function bits are in bits 10–15.
+     *
+     * @return raw 16-bit Mask/Enable register value
+     */
+    int alertFlags() {
+        readReg(REG_MASK_EN)
+    }
+
+    /**
+     * Reset the chip (sets RST bit) and re-write calibration.
+     *
+     * <p>After reset the chip returns to default configuration (0x4127). This method
+     * re-writes the Calibration register so that current and power readings remain valid.
+     */
+    void reset() {
+        writeReg(REG_CONFIG, 0x8000)
+        writeReg(REG_CAL, cal)
+        lastMode = 7
+    }
+
+    /**
+     * Put the chip into power-down mode (MODE=000).
+     *
+     * <p>The current mode is preserved in {@code lastMode} so that {@link #wake()}
+     * can restore it.
+     */
+    void shutdown() {
+        int cfg = readReg(REG_CONFIG)
+        lastMode = cfg & 0x07
+        writeReg(REG_CONFIG, cfg & ~0x07)
+    }
+
+    /**
+     * Restore the operating mode that was active before {@link #shutdown()}.
+     */
+    void wake() {
+        int cfg = readReg(REG_CONFIG)
+        writeReg(REG_CONFIG, (cfg & ~0x07) | (lastMode & 0x07))
+    }
+
+    /**
+     * Read the Manufacturer ID register.
+     *
+     * @return manufacturer ID (0x5449 = "TI")
+     */
+    int manufacturerId() {
+        readReg(REG_MFR_ID)
+    }
+
+    /**
+     * Read the Die ID register.
+     *
+     * @return die ID (0x2260 for INA226)
+     */
+    int dieId() {
+        readReg(REG_DIE_ID)
+    }
+}

--- a/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina226Minimal.groovy
+++ b/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina226Minimal.groovy
@@ -1,0 +1,150 @@
+package it.uhde.periph.chips.power
+
+import groovy.transform.CompileStatic
+import it.uhde.periph.transport.Transport
+
+/**
+ * INA226 — 16-bit current/power monitor with I²C interface (minimal driver).
+ *
+ * <p>Measures shunt voltage, bus voltage, current, and power. Calibration is
+ * computed from the shunt resistance and maximum expected current; the result
+ * is written to the Calibration register at construction time.
+ *
+ * <p>Default I²C address: 0x40 (A0=GND, A1=GND).
+ *
+ * <h2>Configuration defaults</h2>
+ * <ul>
+ *   <li>Mode: continuous shunt+bus (7)</li>
+ *   <li>Bus voltage conversion time: 1.1 ms (4)</li>
+ *   <li>Shunt voltage conversion time: 1.1 ms (4)</li>
+ *   <li>Averaging: 1 sample (0)</li>
+ * </ul>
+ */
+@CompileStatic
+class Ina226Minimal {
+
+    // --- Register addresses ---
+    protected static final int REG_CONFIG    = 0x00
+    protected static final int REG_SHUNT     = 0x01
+    protected static final int REG_BUS       = 0x02
+    protected static final int REG_POWER     = 0x03
+    protected static final int REG_CURRENT   = 0x04
+    protected static final int REG_CAL       = 0x05
+    protected static final int REG_MASK_EN   = 0x06
+    protected static final int REG_ALERT_LIM = 0x07
+    protected static final int REG_MFR_ID    = 0xFE
+    protected static final int REG_DIE_ID    = 0xFF
+
+    /** Default configuration: mode=7, VBUSCT=4, VSHCT=4, AVG=0 → 0x4127. */
+    protected static final int DEFAULT_CONFIG = 0x4127
+
+    protected final Transport transport
+    protected final double currentLsb
+    protected final int    cal
+    /** Stored MODE bits (2:0) for wake(). Updated by configure() and shutdown(). */
+    protected int lastMode = 7
+
+    /**
+     * Construct the driver with default shunt (0.1 Ω) and max current (2.0 A).
+     *
+     * @param transport I²C transport bound to the INA226 device address
+     */
+    Ina226Minimal(Transport transport) {
+        this(transport, 0.1d, 2.0d)
+    }
+
+    /**
+     * Construct the driver.
+     *
+     * <p>Computes {@code Current_LSB = maxCurrent / 32768} and
+     * {@code CAL = int(0.00512 / (Current_LSB × rShunt))}, then writes
+     * the default configuration register and calibration register.
+     *
+     * @param transport  I²C transport bound to the INA226 device address
+     * @param rShunt     shunt resistor value in Ω (e.g. 0.1)
+     * @param maxCurrent maximum expected current in A (e.g. 2.0)
+     */
+    Ina226Minimal(Transport transport, double rShunt, double maxCurrent) {
+        this.transport  = transport
+        this.currentLsb = maxCurrent / 32768.0d
+        this.cal        = (int) (0.00512d / (currentLsb * rShunt))
+        writeReg(REG_CONFIG, DEFAULT_CONFIG)
+        writeReg(REG_CAL, cal)
+    }
+
+    /**
+     * Read the bus voltage.
+     *
+     * @return bus voltage in V (1.25 mV LSB, unsigned 16-bit)
+     */
+    double voltage() {
+        readReg(REG_BUS) * 1.25e-3d
+    }
+
+    /**
+     * Read the shunt voltage.
+     *
+     * @return shunt voltage in V (2.5 µV LSB, signed 16-bit)
+     */
+    double shuntVoltage() {
+        readRegSigned(REG_SHUNT) * 2.5e-6d
+    }
+
+    /**
+     * Read the current through the shunt resistor.
+     *
+     * <p>Requires a valid Calibration register value (written in the constructor).
+     *
+     * @return current in A (signed, Current_LSB per bit)
+     */
+    double current() {
+        readRegSigned(REG_CURRENT) * currentLsb
+    }
+
+    /**
+     * Read the calculated power.
+     *
+     * <p>Power = 25 × Current_LSB × raw power register (unsigned).
+     *
+     * @return power in W
+     */
+    double power() {
+        readReg(REG_POWER) * 25.0d * currentLsb
+    }
+
+    // ---- low-level helpers ----
+
+    /**
+     * Write a 16-bit value to a register (big-endian, register-pointer protocol).
+     *
+     * @param reg register address
+     * @param val 16-bit value
+     */
+    protected void writeReg(int reg, int val) {
+        transport.write([(byte) reg, (byte) (val >> 8), (byte) (val & 0xFF)] as byte[])
+    }
+
+    /**
+     * Read an unsigned 16-bit value from a register.
+     *
+     * @param reg register address
+     * @return unsigned 16-bit value (0–65535)
+     */
+    protected int readReg(int reg) {
+        byte[] b = transport.writeRead([(byte) reg] as byte[], 2)
+        ((b[0] & 0xFF) << 8) | (b[1] & 0xFF)
+    }
+
+    /**
+     * Read a signed 16-bit value from a register.
+     *
+     * @param reg register address
+     * @return signed 16-bit value (-32768–32767)
+     */
+    protected int readRegSigned(int reg) {
+        byte[] b = transport.writeRead([(byte) reg] as byte[], 2)
+        def v = ((b[0] & 0xFF) << 8) | (b[1] & 0xFF)
+        if (v > 32767) v -= 65536
+        v
+    }
+}

--- a/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina3221Full.groovy
+++ b/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina3221Full.groovy
@@ -1,0 +1,280 @@
+package it.uhde.periph.chips.power
+
+import groovy.transform.CompileStatic
+import it.uhde.periph.transport.Transport
+
+/**
+ * INA3221 — full driver. Extends {@link Ina3221Minimal} with configuration,
+ * per-channel enable/disable, alert limits, summation, power-valid thresholds,
+ * shutdown/wake, and identification registers.
+ *
+ * <h2>Alert flags</h2>
+ * Reading the Mask/Enable register (via {@link #alertFlags()}) also clears the
+ * latched alert flags. Read it once after a monitoring interval to capture and
+ * clear all pending alerts.
+ *
+ * <h2>Mode constants</h2>
+ * <ul>
+ *   <li>{@link #MODE_POWERDOWN} — power-down (0)</li>
+ *   <li>{@link #MODE_SHUNT_TRIG} — shunt triggered (1)</li>
+ *   <li>{@link #MODE_BUS_TRIG} — bus triggered (2)</li>
+ *   <li>{@link #MODE_SHUNT_BUS_TRIG} — shunt + bus triggered (3)</li>
+ *   <li>{@link #MODE_SHUNT_CONT} — shunt continuous (5)</li>
+ *   <li>{@link #MODE_BUS_CONT} — bus continuous (6)</li>
+ *   <li>{@link #MODE_SHUNT_BUS_CONT} — shunt + bus continuous (7, default)</li>
+ * </ul>
+ */
+@CompileStatic
+class Ina3221Full extends Ina3221Minimal {
+
+    // Mode constants
+    static final int MODE_POWERDOWN      = 0
+    static final int MODE_SHUNT_TRIG     = 1
+    static final int MODE_BUS_TRIG       = 2
+    static final int MODE_SHUNT_BUS_TRIG = 3
+    static final int MODE_SHUNT_CONT     = 5
+    static final int MODE_BUS_CONT       = 6
+    static final int MODE_SHUNT_BUS_CONT = 7
+
+    // Mask/Enable bit positions
+    static final int CF1  = 512
+    static final int CF2  = 256
+    static final int CF3  = 128
+    static final int SF   =  64
+    static final int WF1  =  32
+    static final int WF2  =  16
+    static final int WF3  =   8
+    static final int PVF  =   4
+    static final int TCF  =   2
+    static final int CVRF =   1
+
+    // Register addresses (redeclared for access within @CompileStatic subclass)
+    private static final int REG_CONFIG       = 0x00
+    private static final int REG_CH1_CRIT     = 0x07
+    private static final int REG_CH1_WARN     = 0x08
+    private static final int REG_SV_SUM       = 0x0D
+    private static final int REG_SV_SUM_LIMIT = 0x0E
+    private static final int REG_MASK_ENABLE  = 0x0F
+    private static final int REG_PV_UPPER     = 0x10
+    private static final int REG_PV_LOWER     = 0x11
+    private static final int REG_MANUFACTURER = 0xFE
+    private static final int REG_DIE_ID       = 0xFF
+
+    /** Last user-configured MODE bits; saved so wake() can restore them. */
+    private int savedMode = MODE_SHUNT_BUS_CONT
+
+    /**
+     * Construct the full driver with a uniform shunt resistance for all channels.
+     *
+     * @param transport I²C transport bound to the INA3221 device address
+     * @param rShunt    shunt resistance in Ω applied to all three channels
+     */
+    Ina3221Full(Transport transport, double rShunt = 0.1) {
+        super(transport, rShunt)
+    }
+
+    /**
+     * Construct the full driver with per-channel shunt resistances.
+     *
+     * @param transport I²C transport bound to the INA3221 device address
+     * @param rShunts   shunt resistances in Ω for channels 1, 2, and 3
+     */
+    Ina3221Full(Transport transport, double[] rShunts) {
+        super(transport, rShunts)
+    }
+
+    /**
+     * Write the configuration register, preserving the channel-enable bits.
+     *
+     * @param avg    averaging mode (0–7)
+     * @param vbusCt bus voltage conversion time (0–7)
+     * @param vshCt  shunt voltage conversion time (0–7)
+     * @param mode   operating mode (0–7); use MODE_* constants
+     */
+    void configure(int avg, int vbusCt, int vshCt, int mode) {
+        savedMode = mode & 0x07
+        int current = readReg(REG_CONFIG)
+        int channelBits = current & 0x7000
+        int val = channelBits |
+                ((avg    & 0x07) << 9) |
+                ((vbusCt & 0x07) << 6) |
+                ((vshCt  & 0x07) << 3) |
+                 (mode   & 0x07)
+        writeReg(REG_CONFIG, val)
+    }
+
+    /**
+     * Enable or disable a channel.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @param enabled {@code true} to enable, {@code false} to disable
+     */
+    void enableChannel(int channel, boolean enabled) {
+        checkChannel(channel)
+        int bit = 1 << (15 - channel)
+        int cfg = readReg(REG_CONFIG)
+        cfg = enabled ? (cfg | bit) : (cfg & ~bit)
+        writeReg(REG_CONFIG, cfg & 0xFFFF)
+    }
+
+    /**
+     * Read whether a channel is currently enabled.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @return {@code true} if the channel enable bit is set
+     */
+    boolean channelEnabled(int channel) {
+        checkChannel(channel)
+        int bit = 1 << (15 - channel)
+        (readReg(REG_CONFIG) & bit) != 0
+    }
+
+    /**
+     * Read the Conversion Ready Flag (CVRF) from the Mask/Enable register.
+     *
+     * @return {@code true} if a conversion cycle has completed since the last read
+     */
+    boolean conversionReady() {
+        (readReg(REG_MASK_ENABLE) & CVRF) != 0
+    }
+
+    /**
+     * Set the critical alert limit for a channel.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @param limitV  shunt voltage threshold in V (positive)
+     */
+    void setCriticalAlert(int channel, double limitV) {
+        checkChannel(channel)
+        int reg = REG_CH1_CRIT + (channel - 1) * 2
+        writeReg(reg, encodeAlertLimit(limitV))
+    }
+
+    /**
+     * Set the warning alert limit for a channel.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @param limitV  shunt voltage threshold in V (positive)
+     */
+    void setWarningAlert(int channel, double limitV) {
+        checkChannel(channel)
+        int reg = REG_CH1_WARN + (channel - 1) * 2
+        writeReg(reg, encodeAlertLimit(limitV))
+    }
+
+    /**
+     * Read and clear the Mask/Enable register (alert flags).
+     *
+     * @return the raw 16-bit Mask/Enable register value
+     */
+    int alertFlags() {
+        readReg(REG_MASK_ENABLE)
+    }
+
+    /**
+     * Set the summation channel selection (SCC) bits and the summation limit.
+     *
+     * @param channels array of channel numbers to include in the sum (values 1–3)
+     * @param limitV   summation shunt voltage limit in V
+     */
+    void setSummationChannels(int[] channels, double limitV) {
+        int me = readReg(REG_MASK_ENABLE) & 0x0FFF
+        for (int ch : channels) {
+            checkChannel(ch)
+            me |= (1 << (15 - ch))
+        }
+        writeReg(REG_MASK_ENABLE, me & 0xFFFF)
+        int raw = ((int) Math.round(limitV / 40e-6)) & 0x7FFE
+        writeReg(REG_SV_SUM_LIMIT, (raw << 1) & 0xFFFE)
+    }
+
+    /**
+     * Read the shunt-voltage sum register.
+     *
+     * @return shunt-voltage sum in V
+     */
+    double summationValue() {
+        def raw = readReg(REG_SV_SUM)
+        def signed = (short) raw
+        (signed >> 1) * 40e-6
+    }
+
+    /**
+     * Set the power-valid upper and lower voltage thresholds.
+     *
+     * @param upperV upper threshold in V (register 0x10)
+     * @param lowerV lower threshold in V (register 0x11)
+     */
+    void setPowerValidLimits(double upperV, double lowerV) {
+        writeReg(REG_PV_UPPER, (((int) Math.round(upperV / 8e-3)) & 0x1FFF) << 3)
+        writeReg(REG_PV_LOWER, (((int) Math.round(lowerV / 8e-3)) & 0x1FFF) << 3)
+    }
+
+    /**
+     * Read the Power Valid Flag (PVF) from the Mask/Enable register.
+     *
+     * @return {@code true} if all enabled channels are within the power-valid window
+     */
+    boolean powerValid() {
+        (readReg(REG_MASK_ENABLE) & PVF) != 0
+    }
+
+    /**
+     * Put the device into power-down mode (MODE = 000).
+     *
+     * <p>The current MODE setting is saved so that {@link #wake()} can restore it.
+     */
+    void shutdown() {
+        int cfg = readReg(REG_CONFIG)
+        savedMode = cfg & 0x07
+        writeReg(REG_CONFIG, (cfg & 0xFFF8) | MODE_POWERDOWN)
+    }
+
+    /**
+     * Restore the operating mode saved by the last call to {@link #shutdown()} or
+     * {@link #configure(int,int,int,int)}.
+     */
+    void wake() {
+        int cfg = readReg(REG_CONFIG)
+        writeReg(REG_CONFIG, (cfg & 0xFFF8) | (savedMode & 0x07))
+    }
+
+    /**
+     * Trigger a software reset by setting the RST bit, then restore the saved mode.
+     */
+    void reset() {
+        writeReg(REG_CONFIG, 0x8000)
+        int defaults = 0x7127
+        writeReg(REG_CONFIG, (defaults & 0xFFF8) | (savedMode & 0x07))
+    }
+
+    /**
+     * Read the Manufacturer ID register.
+     *
+     * <p>Expected value: 0x5449 ("TI").
+     *
+     * @return manufacturer ID
+     */
+    int manufacturerId() {
+        readReg(REG_MANUFACTURER)
+    }
+
+    /**
+     * Read the Die ID register.
+     *
+     * <p>Expected value: 0x3220.
+     *
+     * @return die ID
+     */
+    int dieId() {
+        readReg(REG_DIE_ID)
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private static int encodeAlertLimit(double limitV) {
+        (((int) Math.round(limitV / 40e-6)) << 3) & 0xFFF8
+    }
+}

--- a/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina3221Minimal.groovy
+++ b/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina3221Minimal.groovy
@@ -1,0 +1,149 @@
+package it.uhde.periph.chips.power
+
+import groovy.transform.CompileStatic
+import it.uhde.periph.transport.Transport
+
+/**
+ * INA3221 — 3-channel, high-side measurement, shunt and bus voltage monitor
+ * with I²C interface (minimal driver).
+ *
+ * <p>Measures bus voltage and shunt voltage on up to three independent channels.
+ * Current and power are computed in software from the shunt voltage and the
+ * per-channel shunt resistance supplied at construction time. There is no
+ * calibration register; all scaling is done in the driver.
+ *
+ * <p>The constructor does not write any registers — the chip's hardware reset
+ * default (configuration register 0x7127: all channels enabled, 1-sample
+ * averaging, 1.1 ms conversion, continuous shunt+bus mode) is suitable for
+ * immediate use.
+ *
+ * <p>Default I²C address: 0x40 (A0=GND, A1=GND).
+ */
+@CompileStatic
+class Ina3221Minimal {
+
+    protected static final int[] SHUNT_BASE = [0, 0x01, 0x03, 0x05] as int[]
+    protected static final int[] BUS_BASE   = [0, 0x02, 0x04, 0x06] as int[]
+
+    protected final Transport transport
+    /** Per-channel shunt resistances in Ω (index 0 = channel 1). */
+    protected final double[] rShunts
+
+    /**
+     * Construct the driver with a uniform shunt resistance for all three channels.
+     *
+     * <p>No registers are written; the hardware reset defaults are used.
+     *
+     * @param transport I²C transport bound to the INA3221 device address
+     * @param rShunt    shunt resistance in Ω applied to all three channels (e.g. 0.1)
+     */
+    Ina3221Minimal(Transport transport, double rShunt = 0.1) {
+        this.transport = transport
+        this.rShunts   = [rShunt, rShunt, rShunt] as double[]
+    }
+
+    /**
+     * Construct the driver with per-channel shunt resistances.
+     *
+     * @param transport I²C transport bound to the INA3221 device address
+     * @param rShunts   shunt resistances in Ω for channels 1, 2, and 3 (length must be 3)
+     */
+    Ina3221Minimal(Transport transport, double[] rShunts) {
+        if (rShunts == null || rShunts.length != 3)
+            throw new IllegalArgumentException('rShunts must have exactly 3 elements')
+        this.transport = transport
+        this.rShunts   = rShunts.clone() as double[]
+    }
+
+    /**
+     * Read the bus voltage for a channel.
+     *
+     * <p>Reads the left-aligned 12-bit unsigned bus voltage register, right-shifts
+     * by 3, and multiplies by the 8 mV LSB.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @return bus voltage in V
+     */
+    double voltage(int channel) {
+        checkChannel(channel)
+        int raw = readReg(BUS_BASE[channel])
+        (raw >> 3) * 8e-3
+    }
+
+    /**
+     * Read the shunt voltage for a channel.
+     *
+     * <p>Reads the left-aligned 13-bit signed shunt voltage register, right-shifts
+     * by 3 (arithmetic), and multiplies by the 40 µV LSB.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @return shunt voltage in V (may be negative)
+     */
+    double shuntVoltage(int channel) {
+        checkChannel(channel)
+        def raw = readReg(SHUNT_BASE[channel])
+        def signed = (short) raw
+        (signed >> 3) * 40e-6
+    }
+
+    /**
+     * Compute the current through the shunt resistor for a channel.
+     *
+     * <p>Current = shuntVoltage / rShunt[channel].
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @return current in A (may be negative for reverse flow)
+     */
+    double current(int channel) {
+        checkChannel(channel)
+        shuntVoltage(channel) / rShunts[channel - 1]
+    }
+
+    /**
+     * Compute the power consumed on a channel.
+     *
+     * <p>Power = busVoltage × current.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @return power in W
+     */
+    double power(int channel) {
+        checkChannel(channel)
+        voltage(channel) * current(channel)
+    }
+
+    // -------------------------------------------------------------------------
+    // Protected helpers (shared with Ina3221Full)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Read a 16-bit big-endian register.
+     *
+     * @param reg register address
+     * @return raw unsigned 16-bit value
+     */
+    protected int readReg(int reg) {
+        byte[] b = transport.writeRead([(byte) reg] as byte[], 2)
+        ((b[0] & 0xFF) << 8) | (b[1] & 0xFF)
+    }
+
+    /**
+     * Write a 16-bit big-endian register.
+     *
+     * @param reg register address
+     * @param val 16-bit value to write
+     */
+    protected void writeReg(int reg, int val) {
+        transport.write([(byte) reg, (byte) ((val >> 8) & 0xFF), (byte) (val & 0xFF)] as byte[])
+    }
+
+    /**
+     * Validate that a channel number is 1, 2, or 3.
+     *
+     * @param channel channel number to validate
+     */
+    protected static void checkChannel(int channel) {
+        if (channel < 1 || channel > 3)
+            throw new IllegalArgumentException("channel must be 1-3, got: ${channel}")
+    }
+}

--- a/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/pressure/Bmp180Full.groovy
+++ b/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/pressure/Bmp180Full.groovy
@@ -1,0 +1,128 @@
+package it.uhde.periph.chips.pressure
+
+import groovy.transform.CompileStatic
+import it.uhde.periph.transport.Transport
+import java.io.IOException
+
+/**
+ * BMP180 — full driver. Extends {@link Bmp180Minimal} with oversampling control,
+ * altitude calculation, sea-level pressure derivation, chip ID read-back, and
+ * soft reset.
+ *
+ * <h2>OSS constants</h2>
+ * {@link #OSS_ULP}, {@link #OSS_STANDARD}, {@link #OSS_HIGH_RES}, {@link #OSS_ULTRA_HIGH_RES}
+ *
+ * <h2>Altitude formula</h2>
+ * {@code altitude_m = 44330.0 × (1.0 − (pressure_hPa / seaLevelHpa)^(1/5.255))}
+ */
+@CompileStatic
+class Bmp180Full extends Bmp180Minimal {
+
+    /** Ultra-low-power mode: OSS = 0 (1 sample, ~4.5 ms, 3 µA RMS). */
+    static final int OSS_ULP             = 0
+    /** Standard mode: OSS = 1 (2 samples, ~7.5 ms, 5 µA RMS). */
+    static final int OSS_STANDARD        = 1
+    /** High-resolution mode: OSS = 2 (4 samples, ~13.5 ms, 7 µA RMS). */
+    static final int OSS_HIGH_RES        = 2
+    /** Ultra-high-resolution mode: OSS = 3 (8 samples, ~25.5 ms, 12 µA RMS). */
+    static final int OSS_ULTRA_HIGH_RES  = 3
+
+    private static final double DEFAULT_SEA_LEVEL_HPA = 1013.25
+
+    /**
+     * Construct the full driver, verify chip ID, and load calibration.
+     *
+     * @param transport I²C transport bound to address 0x77
+     * @throws IOException on I²C error, wrong chip ID, or invalid calibration
+     */
+    Bmp180Full(Transport transport) {
+        super(transport)
+    }
+
+    /**
+     * Read the current oversampling setting.
+     *
+     * @return OSS value (0–3)
+     */
+    int oversampling() {
+        return oss
+    }
+
+    /**
+     * Set the oversampling setting.
+     *
+     * @param oss oversampling value (0–3); use the OSS_* constants
+     * @throws IllegalArgumentException if oss is outside [0, 3]
+     */
+    void setOversampling(int oss) {
+        if (oss < 0 || oss > 3) {
+            throw new IllegalArgumentException("OSS must be 0–3, got: ${oss}")
+        }
+        this.oss = oss
+    }
+
+    /**
+     * Compute altitude using the default sea-level pressure (1013.25 hPa).
+     *
+     * @return altitude in m
+     * @throws IOException on I²C error
+     */
+    double altitude() {
+        return altitude(DEFAULT_SEA_LEVEL_HPA)
+    }
+
+    /**
+     * Compute altitude for a given sea-level reference pressure.
+     *
+     * <p>Uses the barometric formula:
+     * {@code altitude_m = 44330 × (1 − (pressure / seaLevelHpa)^(1/5.255))}
+     *
+     * @param seaLevelHpa reference sea-level pressure in hPa
+     * @return altitude in m
+     * @throws IOException on I²C error
+     */
+    double altitude(double seaLevelHpa) {
+        double p = pressure()
+        return 44330.0 * (1.0 - Math.pow(p / seaLevelHpa, 1.0 / 5.255))
+    }
+
+    /**
+     * Back-calculate the sea-level pressure from the current reading and a
+     * known altitude.
+     *
+     * @param altitudeM known altitude in m
+     * @return sea-level pressure in hPa
+     * @throws IOException on I²C error
+     */
+    double seaLevelPressure(double altitudeM) {
+        double p = pressure()
+        return p / Math.pow(1.0 - altitudeM / 44330.0, 5.255)
+    }
+
+    /**
+     * Read the chip ID register (0xD0).
+     *
+     * <p>Expected value is 0x55 for BMP180.
+     *
+     * @return chip ID byte
+     * @throws IOException on I²C error
+     */
+    int chipId() {
+        byte[] b = transport.writeRead([(byte) REG_ID] as byte[], 1)
+        return b[0] & 0xFF
+    }
+
+    /**
+     * Perform a soft reset and reload calibration.
+     *
+     * <p>Writes 0xB6 to register 0xE0, waits 15 ms for the chip to complete its
+     * power-on sequence, then re-reads and validates the calibration EEPROM.
+     *
+     * @throws IOException on I²C error or invalid calibration after reset
+     */
+    void reset() {
+        transport.write([(byte) REG_SOFT_RST, (byte) 0xB6] as byte[])
+        Thread.sleep(15)
+        readCalibration()
+    }
+}

--- a/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/pressure/Bmp180Minimal.groovy
+++ b/jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/pressure/Bmp180Minimal.groovy
@@ -1,0 +1,200 @@
+package it.uhde.periph.chips.pressure
+
+import groovy.transform.CompileStatic
+import it.uhde.periph.transport.Transport
+import java.io.IOException
+
+/**
+ * BMP180 — digital barometric pressure and temperature sensor (minimal driver).
+ *
+ * <p>Reads temperature and pressure via I²C using Bosch's integer compensation
+ * algorithm. Calibration coefficients are loaded from the chip's EEPROM during
+ * construction and sanity-checked. The chip ID register is verified to be 0x55.
+ *
+ * <p>Fixed I²C address: 0x77 (hardware-defined, not configurable).
+ *
+ * <p>Default oversampling setting (OSS): 0 (ultra-low-power).
+ */
+@CompileStatic
+class Bmp180Minimal {
+
+    static final int REG_CAL_START = 0xAA
+    static final int REG_ID        = 0xD0
+    static final int REG_SOFT_RST  = 0xE0
+    static final int REG_CTRL_MEAS = 0xF4
+    static final int REG_OUT_MSB   = 0xF6
+    static final int CMD_TEMP      = 0x2E
+    static final int CMD_PRES_OSS  = 0x34
+    static final int CHIP_ID       = 0x55
+
+    protected final Transport transport
+
+    // Calibration coefficients (signed unless noted)
+    protected int AC1, AC2, AC3
+    protected int AC4, AC5, AC6   // unsigned uint16 — mask with 0xFFFF when needed
+    protected int B1, B2
+    protected int MB, MC, MD
+
+    /** Current oversampling setting (0–3). */
+    protected int oss = 0
+
+    /**
+     * Construct the driver, verify the chip ID, and load calibration data.
+     *
+     * @param transport I²C transport bound to address 0x77
+     * @throws IOException on I²C error, wrong chip ID, or invalid calibration
+     */
+    Bmp180Minimal(Transport transport) {
+        this.transport = transport
+
+        byte[] id = transport.writeRead([(byte) REG_ID] as byte[], 1)
+        if ((id[0] & 0xFF) != CHIP_ID) {
+            throw new IOException(
+                "BMP180 not found: expected chip ID 0x55, got 0x" +
+                Integer.toHexString(id[0] & 0xFF))
+        }
+
+        readCalibration()
+    }
+
+    /**
+     * Read and unpack the 22-byte calibration block from EEPROM (0xAA–0xBF).
+     *
+     * @throws IOException on I²C error or invalid calibration data
+     */
+    protected void readCalibration() {
+        byte[] cal = transport.writeRead([(byte) REG_CAL_START] as byte[], 22)
+
+        AC1 = (short)(((cal[0]  & 0xFF) << 8) | (cal[1]  & 0xFF))
+        AC2 = (short)(((cal[2]  & 0xFF) << 8) | (cal[3]  & 0xFF))
+        AC3 = (short)(((cal[4]  & 0xFF) << 8) | (cal[5]  & 0xFF))
+        AC4 =          ((cal[6]  & 0xFF) << 8) | (cal[7]  & 0xFF)   // uint16
+        AC5 =          ((cal[8]  & 0xFF) << 8) | (cal[9]  & 0xFF)   // uint16
+        AC6 =          ((cal[10] & 0xFF) << 8) | (cal[11] & 0xFF)   // uint16
+        B1  = (short)(((cal[12] & 0xFF) << 8) | (cal[13] & 0xFF))
+        B2  = (short)(((cal[14] & 0xFF) << 8) | (cal[15] & 0xFF))
+        MB  = (short)(((cal[16] & 0xFF) << 8) | (cal[17] & 0xFF))
+        MC  = (short)(((cal[18] & 0xFF) << 8) | (cal[19] & 0xFF))
+        MD  = (short)(((cal[20] & 0xFF) << 8) | (cal[21] & 0xFF))
+
+        checkCalibration()
+    }
+
+    /**
+     * Sanity-check: no coefficient may be 0x0000 or 0xFFFF.
+     *
+     * @throws IOException if any coefficient is 0x0000 or 0xFFFF
+     */
+    protected void checkCalibration() {
+        int[] raw16 = [
+            AC1 & 0xFFFF, AC2 & 0xFFFF, AC3 & 0xFFFF,
+            AC4 & 0xFFFF, AC5 & 0xFFFF, AC6 & 0xFFFF,
+            B1  & 0xFFFF, B2  & 0xFFFF,
+            MB  & 0xFFFF, MC  & 0xFFFF, MD  & 0xFFFF
+        ] as int[]
+        String[] names = ['AC1','AC2','AC3','AC4','AC5','AC6','B1','B2','MB','MC','MD'] as String[]
+        for (int i = 0; i < raw16.length; i++) {
+            if (raw16[i] == 0x0000 || raw16[i] == 0xFFFF) {
+                throw new IOException(
+                    "BMP180 calibration invalid: ${names[i]} = 0x${Integer.toHexString(raw16[i])}")
+            }
+        }
+    }
+
+    /**
+     * Trigger a temperature measurement and return the raw ADC value (UT).
+     *
+     * @return unsigned 16-bit raw temperature
+     * @throws IOException on I²C error
+     */
+    protected int readRawTemperature() {
+        transport.write([(byte) REG_CTRL_MEAS, (byte) CMD_TEMP] as byte[])
+        Thread.sleep(5)
+        byte[] b = transport.writeRead([(byte) REG_OUT_MSB] as byte[], 2)
+        return ((b[0] & 0xFF) << 8) | (b[1] & 0xFF)
+    }
+
+    /**
+     * Trigger a pressure measurement and return the raw ADC value (UP).
+     *
+     * @param ossMode oversampling setting (0–3)
+     * @return raw pressure ADC value (shifted by oss)
+     * @throws IOException on I²C error
+     */
+    protected long readRawPressure(int ossMode) {
+        transport.write([(byte) REG_CTRL_MEAS, (byte)(CMD_PRES_OSS | (ossMode << 6))] as byte[])
+        Thread.sleep((long)(ossMode * 10L + 5L))
+        byte[] b = transport.writeRead([(byte) REG_OUT_MSB] as byte[], 3)
+        long raw = (((long)(b[0] & 0xFF)) << 16) | (((long)(b[1] & 0xFF)) << 8) | ((long)(b[2] & 0xFF))
+        return raw >> (8 - ossMode)
+    }
+
+    /**
+     * Compute B5 from a raw temperature value (UT).
+     *
+     * @param UT raw temperature ADC value
+     * @return B5 (shared intermediate used by both temperature and pressure compensation)
+     */
+    protected long computeB5(int UT) {
+        long X1 = (((long) UT - (long) AC6) * (long) AC5) >> 15
+        long X2 = (((long) MC << 11) / (X1 + (long) MD)).toLong()
+        return X1 + X2
+    }
+
+    /**
+     * Read the temperature.
+     *
+     * <p>Triggers a temperature measurement, runs Bosch integer compensation,
+     * and returns the result in degrees Celsius.
+     *
+     * @return temperature in °C
+     * @throws IOException on I²C error
+     */
+    double temperature() {
+        int  UT = readRawTemperature()
+        long B5 = computeB5(UT)
+        long T  = (B5 + 8L) >> 4
+        return T / 10.0
+    }
+
+    /**
+     * Read the pressure.
+     *
+     * <p>Re-reads temperature internally to refresh B5, then triggers a pressure
+     * measurement. Runs Bosch integer compensation and returns the result in hPa.
+     *
+     * @return pressure in hPa
+     * @throws IOException on I²C error
+     */
+    double pressure() {
+        int  UT = readRawTemperature()
+        long B5 = computeB5(UT)
+        long UP = readRawPressure(oss)
+
+        long B6 = B5 - 4000L
+        long X1 = ((long) B2 * ((B6 * B6) >> 12)) >> 11
+        long X2 = ((long) AC2 * B6) >> 11
+        long X3 = X1 + X2
+        long B3 = ((((long) AC1 * 4L + X3) << oss) + 2L) >> 2
+
+        X1 = ((long) AC3 * B6) >> 13
+        X2 = ((long) B1 * ((B6 * B6) >> 12)) >> 16
+        X3 = ((X1 + X2) + 2L) >> 2
+        long B4 = ((long)(AC4 & 0xFFFFFFFFL)) * (X3 + 32768L) >>> 15
+        long B7 = (UP - B3) * (50000L >> oss)
+
+        long p
+        if (B7 < 0x80000000L) {
+            p = ((B7 * 2L) / B4).toLong()
+        } else {
+            p = ((B7 / B4) * 2L).toLong()
+        }
+
+        X1 = (p >> 8) * (p >> 8)
+        X1 = (X1 * 3038L) >> 16
+        X2 = (-7357L * p) >> 16
+        p  = p + ((X1 + X2 + 3791L) >> 4)
+
+        return p / 100.0
+    }
+}

--- a/jvm/periph-java/pom.xml
+++ b/jvm/periph-java/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it.uhde</groupId>
+        <artifactId>periph</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>periph-java</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>it.uhde</groupId>
+            <artifactId>periph-transport</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/jvm/periph-java/src/main/java/it/uhde/periph/chips/adc_dac/Mcp4725Full.java
+++ b/jvm/periph-java/src/main/java/it/uhde/periph/chips/adc_dac/Mcp4725Full.java
@@ -1,0 +1,165 @@
+package it.uhde.periph.chips.adc_dac;
+
+import it.uhde.periph.transport.Transport;
+
+import java.io.IOException;
+
+/**
+ * MCP4725 — full driver. Extends {@link Mcp4725Minimal} with EEPROM persistence,
+ * power-down control, read-back, and General Call commands (reset / wake-up).
+ *
+ * <p>General Call commands (reset, wakeUp) require a second transport bound to
+ * address 0x00. Pass {@code null} to disable those methods.
+ *
+ * <h2>EEPROM write timing</h2>
+ * The EEPROM write takes up to 50 ms. New write commands are silently ignored
+ * while RDY/BSY is low. Poll {@link #isEepromReady()} or wait 50 ms before
+ * issuing a second EEPROM write.
+ */
+public class Mcp4725Full extends Mcp4725Minimal {
+
+    /**
+     * Read-back state of the MCP4725.
+     *
+     * @param code            current DAC register value (0–4095)
+     * @param voltageFraction DAC register value as fraction of V_DD (code / 4095.0)
+     * @param powerDown       current power-down mode of the DAC register (0–3)
+     * @param eepromCode      EEPROM-stored DAC value (0–4095)
+     * @param eepromPowerDown EEPROM-stored power-down mode (0–3)
+     * @param eepromReady     true when EEPROM write is complete (RDY/BSY = 1)
+     */
+    public record ReadResult(
+            int code,
+            double voltageFraction,
+            int powerDown,
+            int eepromCode,
+            int eepromPowerDown,
+            boolean eepromReady
+    ) {}
+
+    private final Transport generalCall;
+
+    /**
+     * Construct the full driver.
+     *
+     * @param transport   I²C transport bound to the MCP4725 device address
+     * @param generalCall I²C transport bound to address 0x00 for General Call
+     *                    commands, or {@code null} to disable reset/wakeUp
+     */
+    public Mcp4725Full(Transport transport, Transport generalCall) {
+        super(transport);
+        this.generalCall = generalCall;
+    }
+
+    /**
+     * Write fraction to both the DAC register and EEPROM.
+     *
+     * @param fraction target output level, 0.0–1.0
+     * @throws IOException on I²C error
+     */
+    public void setVoltageEeprom(double fraction) throws IOException {
+        fraction = Math.max(0.0, Math.min(1.0, fraction));
+        setRawEeprom((int) Math.round(fraction * 4095));
+    }
+
+    /**
+     * Write a raw 12-bit code to both the DAC register and EEPROM.
+     *
+     * <p>The value persists across power cycles. Wait up to 50 ms before
+     * issuing another EEPROM write.
+     *
+     * @param code 12-bit DAC value (0–4095)
+     * @throws IOException on I²C error
+     */
+    public void setRawEeprom(int code) throws IOException {
+        code = Math.max(0, Math.min(4095, code));
+        lastCode = code;
+        // Write DAC + EEPROM command: C2=0 C1=1 C0=1 → 0b011x_xPD1_PD0_x
+        // Byte 1: [0 1 1 X X PD1 PD0 X] = 0x60 (normal mode)
+        // Byte 2: D11–D4
+        // Byte 3: D3–D0 in bits 7:4, bits 3:0 don't care
+        transport.write(new byte[]{
+                0x60,
+                (byte) ((code >> 4) & 0xFF),
+                (byte) ((code << 4) & 0xF0)
+        });
+    }
+
+    /**
+     * Read the current state of the device (5-byte read response).
+     *
+     * @return snapshot of DAC register, EEPROM, power-down, and ready flag
+     * @throws IOException on I²C error
+     */
+    public ReadResult read() throws IOException {
+        byte[] b = transport.read(5);
+        boolean eepromReady = (b[0] & 0x80) != 0;
+        int powerDown      = (b[0] >> 2) & 0x03;
+        int code           = ((b[1] & 0xFF) << 4) | ((b[2] & 0xFF) >> 4);
+        int eepromPD       = (b[3] >> 5) & 0x03;
+        int eepromCode     = ((b[3] & 0x0F) << 8) | (b[4] & 0xFF);
+        return new ReadResult(code, code / 4095.0, powerDown, eepromCode, eepromPD, eepromReady);
+    }
+
+    /**
+     * Enter or exit power-down mode using a Fast Write.
+     *
+     * <p>The last-written DAC code is preserved in the output register so the
+     * output resumes at the same level when mode 0 is selected again.
+     *
+     * @param mode 0 = normal, 1 = 1 kΩ to GND, 2 = 100 kΩ to GND, 3 = 500 kΩ to GND
+     * @throws IOException on I²C error
+     */
+    public void setPowerDown(int mode) throws IOException {
+        mode = Math.max(0, Math.min(3, mode));
+        // Fast Write with PD bits set: [0 0 PD1 PD0 D11-D8] [D7-D0]
+        transport.write(new byte[]{
+                (byte) (((mode & 0x03) << 4) | ((lastCode >> 8) & 0x0F)),
+                (byte) (lastCode & 0xFF)
+        });
+    }
+
+    /**
+     * Send General Call Wake-Up (address 0x00, command 0x09).
+     *
+     * <p>Clears the power-down bits in the DAC register of all MCP47xx devices
+     * on the bus that support General Call.
+     *
+     * @throws IOException              on I²C error
+     * @throws IllegalStateException    if no General Call transport was provided
+     */
+    public void wakeUp() throws IOException {
+        requireGeneralCall();
+        generalCall.write(new byte[]{0x09});
+    }
+
+    /**
+     * Send General Call Reset (address 0x00, command 0x06).
+     *
+     * <p>Triggers an internal power-on reset on all MCP47xx devices on the bus
+     * that support General Call, reloading EEPROM contents into the DAC register.
+     *
+     * @throws IOException              on I²C error
+     * @throws IllegalStateException    if no General Call transport was provided
+     */
+    public void reset() throws IOException {
+        requireGeneralCall();
+        generalCall.write(new byte[]{0x06});
+    }
+
+    /**
+     * Read the RDY/BSY bit.
+     *
+     * @return true when the EEPROM write is complete
+     * @throws IOException on I²C error
+     */
+    public boolean isEepromReady() throws IOException {
+        byte[] b = transport.read(1);
+        return (b[0] & 0x80) != 0;
+    }
+
+    private void requireGeneralCall() {
+        if (generalCall == null)
+            throw new IllegalStateException("General Call transport not configured");
+    }
+}

--- a/jvm/periph-java/src/main/java/it/uhde/periph/chips/adc_dac/Mcp4725Minimal.java
+++ b/jvm/periph-java/src/main/java/it/uhde/periph/chips/adc_dac/Mcp4725Minimal.java
@@ -1,0 +1,62 @@
+package it.uhde.periph.chips.adc_dac;
+
+import it.uhde.periph.transport.Transport;
+
+import java.io.IOException;
+
+/**
+ * MCP4725 — 12-bit single-channel DAC with I²C interface (minimal driver).
+ *
+ * <p>Outputs a voltage from 0 V to V_DD by writing a 12-bit code over I²C.
+ * Only the DAC register is updated; the EEPROM is never touched by this class.
+ * All writes use the Fast Write command (2 bytes).
+ *
+ * <p>Default I²C address: 0x60 (A0 pin = GND), 0x61 (A0 pin = VDD).
+ */
+public class Mcp4725Minimal {
+
+    protected final Transport transport;
+    /** Last code written; used by subclass setPowerDown to preserve the output level. */
+    protected int lastCode = 0;
+
+    /**
+     * Construct the driver.
+     *
+     * @param transport I²C transport bound to the MCP4725 device address
+     */
+    public Mcp4725Minimal(Transport transport) {
+        this.transport = transport;
+    }
+
+    /**
+     * Set the DAC output as a fraction of V_DD using a Fast Write.
+     *
+     * <p>Fraction is clamped to [0.0, 1.0]. Maps to a 12-bit code via
+     * {@code code = round(fraction × 4095)}.
+     *
+     * @param fraction target output level, 0.0 = 0 V, 1.0 = V_DD
+     * @throws IOException on I²C error
+     */
+    public void setVoltage(double fraction) throws IOException {
+        fraction = Math.max(0.0, Math.min(1.0, fraction));
+        setRaw((int) Math.round(fraction * 4095));
+    }
+
+    /**
+     * Set the DAC output to a raw 12-bit code using a Fast Write.
+     *
+     * <p>Code is clamped to [0, 4095]. Output voltage = V_DD × code / 4096.
+     *
+     * @param code 12-bit DAC value (0–4095)
+     * @throws IOException on I²C error
+     */
+    public void setRaw(int code) throws IOException {
+        code = Math.max(0, Math.min(4095, code));
+        lastCode = code;
+        // Fast Write: [0 0 PD1 PD0 D11-D8] [D7-D0]  — PD1=PD0=0 (normal mode)
+        transport.write(new byte[]{
+                (byte) ((code >> 8) & 0x0F),
+                (byte) (code & 0xFF)
+        });
+    }
+}

--- a/jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina219Full.java
+++ b/jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina219Full.java
@@ -1,0 +1,263 @@
+package it.uhde.periph.chips.power;
+
+import it.uhde.periph.transport.Transport;
+
+import java.io.IOException;
+
+/**
+ * INA219 — full driver. Extends {@link Ina219Minimal} with ADC configuration,
+ * conversion-ready and overflow status, software reset, power-down, wake, and
+ * one-shot trigger.
+ *
+ * <h2>Configuration register layout (0x00)</h2>
+ * <pre>
+ * Bit 15    : RST  — software reset (self-clearing)
+ * Bit 13    : BRNG — bus voltage range (0 = 16 V, 1 = 32 V)
+ * Bits 12:11: PG   — PGA gain (00 = /1, 01 = /2, 10 = /4, 11 = /8)
+ * Bits 10:7 : BADC — bus ADC resolution / averaging
+ * Bits  6:3 : SADC — shunt ADC resolution / averaging
+ * Bits  2:0 : MODE — operating mode
+ * </pre>
+ *
+ * <h2>PGA constants</h2>
+ * {@link #PGA_1}, {@link #PGA_2}, {@link #PGA_4}, {@link #PGA_8}
+ *
+ * <h2>Bus range constants</h2>
+ * {@link #BRNG_16V}, {@link #BRNG_32V}
+ *
+ * <h2>ADC constants</h2>
+ * {@link #ADC_9BIT}, {@link #ADC_10BIT}, {@link #ADC_11BIT}, {@link #ADC_12BIT},
+ * {@link #ADC_AVG_2}, {@link #ADC_AVG_4}, {@link #ADC_AVG_8}, {@link #ADC_AVG_16},
+ * {@link #ADC_AVG_32}, {@link #ADC_AVG_64}, {@link #ADC_AVG_128}
+ *
+ * <h2>Mode constants</h2>
+ * {@link #MODE_POWERDOWN}, {@link #MODE_SHUNT_TRIG}, {@link #MODE_BUS_TRIG},
+ * {@link #MODE_SHUNT_BUS_TRIG}, {@link #MODE_ADC_OFF}, {@link #MODE_SHUNT_CONT},
+ * {@link #MODE_BUS_CONT}, {@link #MODE_SHUNT_BUS_CONT}
+ */
+public class Ina219Full extends Ina219Minimal {
+
+    // ------------------------------------------------------------------
+    // PGA gain (shunt voltage full-scale range)
+    // ------------------------------------------------------------------
+
+    /** PGA /1: ±40 mV full-scale shunt range. */
+    public static final int PGA_1 = 0;
+    /** PGA /2: ±80 mV full-scale shunt range. */
+    public static final int PGA_2 = 1;
+    /** PGA /4: ±160 mV full-scale shunt range. */
+    public static final int PGA_4 = 2;
+    /** PGA /8: ±320 mV full-scale shunt range (hardware default). */
+    public static final int PGA_8 = 3;
+
+    // ------------------------------------------------------------------
+    // Bus voltage range
+    // ------------------------------------------------------------------
+
+    /** Bus voltage range: 16 V full-scale. */
+    public static final int BRNG_16V = 0;
+    /** Bus voltage range: 32 V full-scale (hardware default). */
+    public static final int BRNG_32V = 1;
+
+    // ------------------------------------------------------------------
+    // ADC resolution / averaging (BADC and SADC fields)
+    // ------------------------------------------------------------------
+
+    /** ADC: 9-bit single sample (84 µs conversion time). */
+    public static final int ADC_9BIT    = 0;
+    /** ADC: 10-bit single sample (148 µs conversion time). */
+    public static final int ADC_10BIT   = 1;
+    /** ADC: 11-bit single sample (276 µs conversion time). */
+    public static final int ADC_11BIT   = 2;
+    /** ADC: 12-bit single sample (532 µs conversion time, hardware default). */
+    public static final int ADC_12BIT   = 3;
+    /** ADC: 2-sample average (1.06 ms). */
+    public static final int ADC_AVG_2   = 9;
+    /** ADC: 4-sample average (2.13 ms). */
+    public static final int ADC_AVG_4   = 10;
+    /** ADC: 8-sample average (4.26 ms). */
+    public static final int ADC_AVG_8   = 11;
+    /** ADC: 16-sample average (8.51 ms). */
+    public static final int ADC_AVG_16  = 12;
+    /** ADC: 32-sample average (17.02 ms). */
+    public static final int ADC_AVG_32  = 13;
+    /** ADC: 64-sample average (34.05 ms). */
+    public static final int ADC_AVG_64  = 14;
+    /** ADC: 128-sample average (68.10 ms). */
+    public static final int ADC_AVG_128 = 15;
+
+    // ------------------------------------------------------------------
+    // Operating modes
+    // ------------------------------------------------------------------
+
+    /** Mode: power-down (low quiescent current, ADC powered off). */
+    public static final int MODE_POWERDOWN      = 0;
+    /** Mode: shunt voltage, triggered (single shot). */
+    public static final int MODE_SHUNT_TRIG     = 1;
+    /** Mode: bus voltage, triggered (single shot). */
+    public static final int MODE_BUS_TRIG       = 2;
+    /** Mode: shunt and bus voltage, triggered (single shot). */
+    public static final int MODE_SHUNT_BUS_TRIG = 3;
+    /** Mode: ADC off (power-down while configuration bits are held). */
+    public static final int MODE_ADC_OFF        = 4;
+    /** Mode: shunt voltage, continuous. */
+    public static final int MODE_SHUNT_CONT     = 5;
+    /** Mode: bus voltage, continuous. */
+    public static final int MODE_BUS_CONT       = 6;
+    /** Mode: shunt and bus voltage, continuous (hardware default). */
+    public static final int MODE_SHUNT_BUS_CONT = 7;
+
+    // ------------------------------------------------------------------
+    // State
+    // ------------------------------------------------------------------
+
+    /** Cached configuration register value (hardware default on power-on). */
+    private int config = 0x399F;
+
+    // ------------------------------------------------------------------
+    // Constructors
+    // ------------------------------------------------------------------
+
+    /**
+     * Construct the full driver.
+     *
+     * @param transport  I²C transport bound to the INA219 device address
+     * @param rShunt     shunt resistance in Ω
+     * @param maxCurrent maximum expected current in A
+     * @throws IOException on I²C error
+     */
+    public Ina219Full(Transport transport, double rShunt, double maxCurrent) throws IOException {
+        super(transport, rShunt, maxCurrent);
+    }
+
+    /**
+     * Construct with default parameters (0.1 Ω shunt, 2.0 A max).
+     *
+     * @param transport I²C transport bound to the INA219 device address
+     * @throws IOException on I²C error
+     */
+    public Ina219Full(Transport transport) throws IOException {
+        super(transport, 0.1, 2.0);
+    }
+
+    // ------------------------------------------------------------------
+    // Configuration
+    // ------------------------------------------------------------------
+
+    /**
+     * Write the configuration register.
+     *
+     * <p>All five fields are packed into the 16-bit register and written
+     * atomically. The value is cached so that {@link #reset()},
+     * {@link #shutdown()}, and {@link #wake()} can restore or modify it without
+     * a read-modify-write bus cycle.
+     *
+     * @param brng bus voltage range (0 = 16 V, 1 = 32 V)
+     * @param pga  PGA gain (0–3); see {@link #PGA_1}–{@link #PGA_8}
+     * @param badc bus ADC resolution/averaging (0–3 or 9–15)
+     * @param sadc shunt ADC resolution/averaging (0–3 or 9–15)
+     * @param mode operating mode (0–7); see {@link #MODE_POWERDOWN}–{@link #MODE_SHUNT_BUS_CONT}
+     * @throws IOException on I²C error
+     */
+    public void configure(int brng, int pga, int badc, int sadc, int mode) throws IOException {
+        config = ((brng & 0x01) << 13)
+               | ((pga  & 0x03) << 11)
+               | ((badc & 0x0F) << 7)
+               | ((sadc & 0x0F) << 3)
+               | (mode  & 0x07);
+        writeReg(REG_CONFIG, config);
+    }
+
+    // ------------------------------------------------------------------
+    // Status
+    // ------------------------------------------------------------------
+
+    /**
+     * Check whether a new conversion result is available.
+     *
+     * <p>Reads the Bus Voltage register and tests the CNVR bit (bit 1). In
+     * triggered modes the bit is set when a complete measurement is ready and
+     * cleared when a new conversion starts or the register is read.
+     *
+     * @return {@code true} when a conversion is ready to be read
+     * @throws IOException on I²C error
+     */
+    public boolean conversionReady() throws IOException {
+        return (readReg(REG_BUS_V) & 0x02) != 0;
+    }
+
+    /**
+     * Check the math overflow flag.
+     *
+     * <p>Reads the Bus Voltage register and tests the OVF bit (bit 0). The flag
+     * is set when the power or current calculation has exceeded the register
+     * capacity; the current and power readings will be invalid until it clears.
+     *
+     * @return {@code true} when an arithmetic overflow has occurred
+     * @throws IOException on I²C error
+     */
+    public boolean overflow() throws IOException {
+        return (readReg(REG_BUS_V) & 0x01) != 0;
+    }
+
+    // ------------------------------------------------------------------
+    // Power control
+    // ------------------------------------------------------------------
+
+    /**
+     * Perform a software reset and restore the configuration and calibration.
+     *
+     * <p>Sets the RST bit (bit 15), which triggers an internal power-on reset.
+     * The hardware resets both the configuration and calibration registers to
+     * their default values; this method re-writes the cached configuration and
+     * recomputes and re-writes the calibration register to restore the driver
+     * to its pre-reset state.
+     *
+     * @throws IOException on I²C error
+     */
+    public void reset() throws IOException {
+        writeReg(REG_CONFIG, 0x8000);
+        writeReg(REG_CONFIG, config);
+        int cal = (int) (0.04096 / (currentLsb * rShunt)) & 0xFFFE;
+        writeReg(REG_CALIBRATE, cal);
+    }
+
+    /**
+     * Enter power-down mode (MODE bits = 000).
+     *
+     * <p>Writes the cached configuration with the MODE field replaced by
+     * {@link #MODE_POWERDOWN}. The remaining configuration bits are preserved.
+     * Call {@link #wake()} to exit.
+     *
+     * @throws IOException on I²C error
+     */
+    public void shutdown() throws IOException {
+        writeReg(REG_CONFIG, (config & ~0x07) | MODE_POWERDOWN);
+    }
+
+    /**
+     * Exit power-down mode by restoring the cached configuration.
+     *
+     * <p>Re-writes the full cached configuration register, reinstating the
+     * original operating mode. Typically called after {@link #shutdown()}.
+     *
+     * @throws IOException on I²C error
+     */
+    public void wake() throws IOException {
+        writeReg(REG_CONFIG, config);
+    }
+
+    /**
+     * Trigger a one-shot conversion by re-writing the configuration register.
+     *
+     * <p>In triggered modes ({@link #MODE_SHUNT_TRIG}, {@link #MODE_BUS_TRIG},
+     * {@link #MODE_SHUNT_BUS_TRIG}) re-writing the configuration register
+     * initiates a new single conversion. Calling this method in continuous mode
+     * has no visible effect but is harmless.
+     *
+     * @throws IOException on I²C error
+     */
+    public void trigger() throws IOException {
+        writeReg(REG_CONFIG, config);
+    }
+}

--- a/jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina219Minimal.java
+++ b/jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina219Minimal.java
@@ -1,0 +1,157 @@
+package it.uhde.periph.chips.power;
+
+import it.uhde.periph.transport.Transport;
+
+import java.io.IOException;
+
+/**
+ * INA219 — zero-drift, bidirectional current/power monitor with I²C interface
+ * (minimal driver).
+ *
+ * <p>Measures bus voltage (0–32 V), shunt voltage, current, and power via a
+ * sense resistor on the high or low side of the load. The calibration register
+ * is computed and written once during construction; the configuration register
+ * is left at its hardware reset value (0x399F: ±32 V bus, PGA /8, 12-bit,
+ * continuous shunt+bus mode).
+ *
+ * <p>Default I²C address: 0x40 (A1=GND, A0=GND).
+ */
+public class Ina219Minimal {
+
+    // Register map
+    protected static final int REG_CONFIG    = 0x00;
+    protected static final int REG_SHUNT_V   = 0x01;
+    protected static final int REG_BUS_V     = 0x02;
+    protected static final int REG_POWER     = 0x03;
+    protected static final int REG_CURRENT   = 0x04;
+    protected static final int REG_CALIBRATE = 0x05;
+
+    protected final Transport transport;
+
+    /** Shunt resistance in Ω — retained for calibration register recalculation. */
+    protected final double rShunt;
+
+    /** Current register LSB in A/LSB. */
+    protected final double currentLsb;
+
+    /** Power register LSB in W/LSB (= 20 × currentLsb). */
+    protected final double powerLsb;
+
+    /**
+     * Construct the driver and program the calibration register.
+     *
+     * <p>Computes {@code Current_LSB = maxCurrent / 32768} and
+     * {@code CAL = floor(0.04096 / (Current_LSB × rShunt)) & 0xFFFE}, then
+     * writes CAL to register 0x05. The configuration register is not touched.
+     *
+     * @param transport  I²C transport bound to the INA219 device address
+     * @param rShunt     shunt resistance in Ω (e.g. 0.1)
+     * @param maxCurrent maximum expected current in A (e.g. 2.0)
+     * @throws IOException on I²C error
+     */
+    public Ina219Minimal(Transport transport, double rShunt, double maxCurrent) throws IOException {
+        this.transport  = transport;
+        this.rShunt     = rShunt;
+        this.currentLsb = maxCurrent / 32768.0;
+        this.powerLsb   = 20.0 * currentLsb;
+        int cal = (int) (0.04096 / (currentLsb * rShunt)) & 0xFFFE;
+        writeReg(REG_CALIBRATE, cal);
+    }
+
+    /**
+     * Construct the driver with default parameters (0.1 Ω shunt, 2.0 A max).
+     *
+     * @param transport I²C transport bound to the INA219 device address
+     * @throws IOException on I²C error
+     */
+    public Ina219Minimal(Transport transport) throws IOException {
+        this(transport, 0.1, 2.0);
+    }
+
+    /**
+     * Read the bus voltage.
+     *
+     * <p>Reads the Bus Voltage register (0x02), right-shifts by 3, and
+     * multiplies by the 4 mV LSB. Range: 0–32 V.
+     *
+     * @return bus voltage in V
+     * @throws IOException on I²C error
+     */
+    public double voltage() throws IOException {
+        int raw = readReg(REG_BUS_V);
+        return ((raw >> 3) & 0x1FFF) * 4e-3;
+    }
+
+    /**
+     * Read the shunt (differential) voltage.
+     *
+     * <p>Reads the Shunt Voltage register (0x01) as a signed 16-bit value and
+     * multiplies by the 10 µV LSB.
+     *
+     * @return shunt voltage in V (negative for reverse current flow)
+     * @throws IOException on I²C error
+     */
+    public double shuntVoltage() throws IOException {
+        int raw = readReg(REG_SHUNT_V);
+        return (short) raw * 10e-6;
+    }
+
+    /**
+     * Read the current through the shunt resistor.
+     *
+     * <p>Reads the Current register (0x04) as a signed 16-bit value and
+     * multiplies by the current LSB computed during construction.
+     *
+     * @return current in A (negative for reverse flow)
+     * @throws IOException on I²C error
+     */
+    public double current() throws IOException {
+        int raw = readReg(REG_CURRENT);
+        return (short) raw * currentLsb;
+    }
+
+    /**
+     * Read the calculated power.
+     *
+     * <p>Reads the Power register (0x03) as an unsigned 16-bit value and
+     * multiplies by the power LSB (= 20 × current LSB).
+     *
+     * @return power in W (always non-negative)
+     * @throws IOException on I²C error
+     */
+    public double power() throws IOException {
+        int raw = readReg(REG_POWER);
+        return (raw & 0xFFFF) * powerLsb;
+    }
+
+    // -------------------------------------------------------------------------
+    // Protected register I/O helpers (shared with Ina219Full)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Read a 16-bit big-endian register.
+     *
+     * @param reg register address (0x00–0x05)
+     * @return raw unsigned 16-bit value
+     * @throws IOException on I²C error
+     */
+    protected int readReg(int reg) throws IOException {
+        byte[] b = transport.writeRead(new byte[]{(byte) reg}, 2);
+        return ((b[0] & 0xFF) << 8) | (b[1] & 0xFF);
+    }
+
+    /**
+     * Write a 16-bit big-endian register.
+     *
+     * @param reg register address (0x00–0x05)
+     * @param val 16-bit value to write
+     * @throws IOException on I²C error
+     */
+    protected void writeReg(int reg, int val) throws IOException {
+        transport.write(new byte[]{
+                (byte) reg,
+                (byte) ((val >> 8) & 0xFF),
+                (byte) (val & 0xFF)
+        });
+    }
+}

--- a/jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina226Full.java
+++ b/jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina226Full.java
@@ -1,0 +1,272 @@
+package it.uhde.periph.chips.power;
+
+import it.uhde.periph.transport.Transport;
+
+import java.io.IOException;
+
+/**
+ * INA226 — full driver. Extends {@link Ina226Minimal} with configuration,
+ * alert management, conversion-ready polling, reset, shutdown/wake, and
+ * device identification.
+ *
+ * <h2>Alert functions (bit positions in Mask/Enable register)</h2>
+ * <ul>
+ *   <li>{@link #SOL}  — shunt over-limit (bit 15)</li>
+ *   <li>{@link #SUL}  — shunt under-limit (bit 14)</li>
+ *   <li>{@link #BOL}  — bus over-limit (bit 13)</li>
+ *   <li>{@link #BUL}  — bus under-limit (bit 12)</li>
+ *   <li>{@link #POL}  — power over-limit (bit 11)</li>
+ *   <li>{@link #CNVR} — conversion ready (bit 10)</li>
+ * </ul>
+ *
+ * <h2>Averaging constants</h2>
+ * {@link #AVG_1}, {@link #AVG_4}, {@link #AVG_16}, {@link #AVG_64},
+ * {@link #AVG_128}, {@link #AVG_256}, {@link #AVG_512}, {@link #AVG_1024}
+ *
+ * <h2>Conversion time constants</h2>
+ * {@link #CT_140US}, {@link #CT_204US}, {@link #CT_332US}, {@link #CT_588US},
+ * {@link #CT_1100US}, {@link #CT_2116US}, {@link #CT_4156US}, {@link #CT_8244US}
+ *
+ * <h2>Mode constants</h2>
+ * {@link #MODE_POWERDOWN}, {@link #MODE_SHUNT_TRIG}, {@link #MODE_BUS_TRIG},
+ * {@link #MODE_SHUNT_BUS_TRIG}, {@link #MODE_SHUNT_CONT}, {@link #MODE_BUS_CONT},
+ * {@link #MODE_SHUNT_BUS_CONT}
+ */
+public class Ina226Full extends Ina226Minimal {
+
+    // --- Alert function constants (bit mask values in Mask/Enable register) ---
+    /** Alert: shunt voltage over-limit (bit 15). */
+    public static final int SOL  = 32768;
+    /** Alert: shunt voltage under-limit (bit 14). */
+    public static final int SUL  = 16384;
+    /** Alert: bus voltage over-limit (bit 13). */
+    public static final int BOL  = 8192;
+    /** Alert: bus voltage under-limit (bit 12). */
+    public static final int BUL  = 4096;
+    /** Alert: power over-limit (bit 11). */
+    public static final int POL  = 2048;
+    /** Alert: conversion ready (bit 10). */
+    public static final int CNVR = 1024;
+
+    // --- Averaging constants ---
+    /** Averaging: 1 sample. */
+    public static final int AVG_1    = 0;
+    /** Averaging: 4 samples. */
+    public static final int AVG_4    = 1;
+    /** Averaging: 16 samples. */
+    public static final int AVG_16   = 2;
+    /** Averaging: 64 samples. */
+    public static final int AVG_64   = 3;
+    /** Averaging: 128 samples. */
+    public static final int AVG_128  = 4;
+    /** Averaging: 256 samples. */
+    public static final int AVG_256  = 5;
+    /** Averaging: 512 samples. */
+    public static final int AVG_512  = 6;
+    /** Averaging: 1024 samples. */
+    public static final int AVG_1024 = 7;
+
+    // --- Conversion time constants ---
+    /** Conversion time: 140 µs. */
+    public static final int CT_140US  = 0;
+    /** Conversion time: 204 µs. */
+    public static final int CT_204US  = 1;
+    /** Conversion time: 332 µs. */
+    public static final int CT_332US  = 2;
+    /** Conversion time: 588 µs. */
+    public static final int CT_588US  = 3;
+    /** Conversion time: 1.1 ms. */
+    public static final int CT_1100US = 4;
+    /** Conversion time: 2.116 ms. */
+    public static final int CT_2116US = 5;
+    /** Conversion time: 4.156 ms. */
+    public static final int CT_4156US = 6;
+    /** Conversion time: 8.244 ms. */
+    public static final int CT_8244US = 7;
+
+    // --- Mode constants ---
+    /** Mode: power-down (0). */
+    public static final int MODE_POWERDOWN       = 0;
+    /** Mode: shunt voltage triggered (1). */
+    public static final int MODE_SHUNT_TRIG      = 1;
+    /** Mode: bus voltage triggered (2). */
+    public static final int MODE_BUS_TRIG        = 2;
+    /** Mode: shunt and bus voltage triggered (3). */
+    public static final int MODE_SHUNT_BUS_TRIG  = 3;
+    /** Mode: shunt voltage continuous (5). */
+    public static final int MODE_SHUNT_CONT      = 5;
+    /** Mode: bus voltage continuous (6). */
+    public static final int MODE_BUS_CONT        = 6;
+    /** Mode: shunt and bus voltage continuous (7). */
+    public static final int MODE_SHUNT_BUS_CONT  = 7;
+
+    /**
+     * Construct the full driver with default shunt (0.1 Ω) and max current (2.0 A).
+     *
+     * @param transport I²C transport bound to the INA226 device address
+     * @throws IOException on I²C error
+     */
+    public Ina226Full(Transport transport) throws IOException {
+        super(transport);
+    }
+
+    /**
+     * Construct the full driver.
+     *
+     * @param transport  I²C transport bound to the INA226 device address
+     * @param rShunt     shunt resistor value in Ω
+     * @param maxCurrent maximum expected current in A
+     * @throws IOException on I²C error
+     */
+    public Ina226Full(Transport transport, double rShunt, double maxCurrent) throws IOException {
+        super(transport, rShunt, maxCurrent);
+    }
+
+    /**
+     * Write the Configuration register.
+     *
+     * <p>Bits 15 (RST) and 12 are reserved/zero. The supplied fields are packed as:
+     * {@code [0 0 0 0 | AVG2 AVG1 AVG0 | VBUSCT2 VBUSCT1 VBUSCT0 | VSHCT2 VSHCT1 VSHCT0 | MODE2 MODE1 MODE0]}.
+     *
+     * @param avg    averaging count (0–7, use {@code AVG_*} constants)
+     * @param vbusCt bus voltage conversion time (0–7, use {@code CT_*} constants)
+     * @param vshCt  shunt voltage conversion time (0–7, use {@code CT_*} constants)
+     * @param mode   operating mode (0–7, use {@code MODE_*} constants)
+     * @throws IOException on I²C error
+     */
+    public void configure(int avg, int vbusCt, int vshCt, int mode) throws IOException {
+        int cfg = ((avg   & 0x07) << 9)
+                | ((vbusCt & 0x07) << 6)
+                | ((vshCt  & 0x07) << 3)
+                |  (mode   & 0x07);
+        lastMode = mode & 0x07;
+        writeReg(REG_CONFIG, cfg);
+    }
+
+    /**
+     * Check whether a conversion has completed (CVRF flag, bit 3 of Mask/Enable).
+     *
+     * @return true if a conversion is ready to be read
+     * @throws IOException on I²C error
+     */
+    public boolean conversionReady() throws IOException {
+        return (readReg(REG_MASK_EN) & 0x08) != 0;
+    }
+
+    /**
+     * Check whether a math overflow occurred (OVF flag, bit 2 of Mask/Enable).
+     *
+     * <p>An overflow means the current or power result exceeded the range of the
+     * register; reduce maxCurrent or increase rShunt to avoid this condition.
+     *
+     * @return true if an overflow has occurred
+     * @throws IOException on I²C error
+     */
+    public boolean overflow() throws IOException {
+        return (readReg(REG_MASK_EN) & 0x04) != 0;
+    }
+
+    /**
+     * Configure an alert function and its threshold.
+     *
+     * <p>The {@code function} value is one of the alert-function constants
+     * ({@link #SOL}, {@link #SUL}, {@link #BOL}, {@link #BUL}, {@link #POL},
+     * {@link #CNVR}). The raw alert limit is derived from the physical limit
+     * according to the function:
+     * <ul>
+     *   <li>SOL/SUL (shunt): raw = int(limit_V / 2.5e-6)</li>
+     *   <li>BOL/BUL (bus):   raw = int(limit_V / 1.25e-3)</li>
+     *   <li>POL (power):     raw = int(limit_W / (25 × Current_LSB))</li>
+     *   <li>CNVR:            limit is ignored (no threshold required)</li>
+     * </ul>
+     *
+     * @param function alert function bitmask (e.g. {@link #POL})
+     * @param limit    physical threshold (V for shunt/bus alerts, W for power alert)
+     * @throws IOException on I²C error
+     */
+    public void setAlert(int function, double limit) throws IOException {
+        int raw;
+        if (function == SOL || function == SUL) {
+            raw = (int) (limit / 2.5e-6);
+        } else if (function == BOL || function == BUL) {
+            raw = (int) (limit / 1.25e-3);
+        } else if (function == POL) {
+            raw = (int) (limit / (25.0 * currentLsb));
+        } else {
+            raw = 0;
+        }
+        writeReg(REG_MASK_EN, function);
+        writeReg(REG_ALERT_LIM, raw & 0xFFFF);
+    }
+
+    /**
+     * Read the raw Mask/Enable register value.
+     *
+     * <p>Reading this register also clears the alert latch. The flags of interest
+     * are CVRF (bit 3) and OVF (bit 2); alert-function bits are in bits 10–15.
+     *
+     * @return raw 16-bit Mask/Enable register value
+     * @throws IOException on I²C error
+     */
+    public int alertFlags() throws IOException {
+        return readReg(REG_MASK_EN);
+    }
+
+    /**
+     * Reset the chip (sets RST bit in Configuration register) and re-write calibration.
+     *
+     * <p>After reset the chip returns to default configuration (0x4127). This method
+     * re-writes the Calibration register so that current and power readings remain valid.
+     *
+     * @throws IOException on I²C error
+     */
+    public void reset() throws IOException {
+        writeReg(REG_CONFIG, 0x8000);
+        writeReg(REG_CAL, cal);
+        lastMode = 7;
+    }
+
+    /**
+     * Put the chip into power-down mode (MODE=000).
+     *
+     * <p>The current mode is preserved in {@code lastMode} so that {@link #wake()}
+     * can restore it.
+     *
+     * @throws IOException on I²C error
+     */
+    public void shutdown() throws IOException {
+        int cfg = readReg(REG_CONFIG);
+        lastMode = cfg & 0x07;
+        writeReg(REG_CONFIG, cfg & ~0x07);
+    }
+
+    /**
+     * Restore the operating mode that was active before {@link #shutdown()}.
+     *
+     * @throws IOException on I²C error
+     */
+    public void wake() throws IOException {
+        int cfg = readReg(REG_CONFIG);
+        writeReg(REG_CONFIG, (cfg & ~0x07) | (lastMode & 0x07));
+    }
+
+    /**
+     * Read the Manufacturer ID register.
+     *
+     * @return manufacturer ID (0x5449 = "TI")
+     * @throws IOException on I²C error
+     */
+    public int manufacturerId() throws IOException {
+        return readReg(REG_MFR_ID);
+    }
+
+    /**
+     * Read the Die ID register.
+     *
+     * @return die ID (0x2260 for INA226)
+     * @throws IOException on I²C error
+     */
+    public int dieId() throws IOException {
+        return readReg(REG_DIE_ID);
+    }
+}

--- a/jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina226Minimal.java
+++ b/jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina226Minimal.java
@@ -1,0 +1,161 @@
+package it.uhde.periph.chips.power;
+
+import it.uhde.periph.transport.Transport;
+
+import java.io.IOException;
+
+/**
+ * INA226 — 16-bit current/power monitor with I²C interface (minimal driver).
+ *
+ * <p>Measures shunt voltage, bus voltage, current, and power. Calibration is
+ * computed from the shunt resistance and maximum expected current; the result
+ * is written to the Calibration register at construction time.
+ *
+ * <p>Default I²C address: 0x40 (A0=GND, A1=GND).
+ *
+ * <h2>Configuration defaults</h2>
+ * <ul>
+ *   <li>Mode: continuous shunt+bus (7)</li>
+ *   <li>Bus voltage conversion time: 1.1 ms (4)</li>
+ *   <li>Shunt voltage conversion time: 1.1 ms (4)</li>
+ *   <li>Averaging: 1 sample (0)</li>
+ * </ul>
+ */
+public class Ina226Minimal {
+
+    // --- Register addresses ---
+    protected static final int REG_CONFIG    = 0x00;
+    protected static final int REG_SHUNT     = 0x01;
+    protected static final int REG_BUS       = 0x02;
+    protected static final int REG_POWER     = 0x03;
+    protected static final int REG_CURRENT   = 0x04;
+    protected static final int REG_CAL       = 0x05;
+    protected static final int REG_MASK_EN   = 0x06;
+    protected static final int REG_ALERT_LIM = 0x07;
+    protected static final int REG_MFR_ID    = 0xFE;
+    protected static final int REG_DIE_ID    = 0xFF;
+
+    /** Default configuration: mode=7, VBUSCT=4, VSHCT=4, AVG=0 → 0x4127. */
+    protected static final int DEFAULT_CONFIG = 0x4127;
+
+    protected final Transport transport;
+    protected final double currentLsb;
+    protected final int    cal;
+    /** Stored MODE bits (2:0) for wake(). Updated by configure() and shutdown(). */
+    protected int lastMode = 7;
+
+    /**
+     * Construct the driver with default shunt (0.1 Ω) and max current (2.0 A).
+     *
+     * @param transport I²C transport bound to the INA226 device address
+     * @throws IOException on I²C error
+     */
+    public Ina226Minimal(Transport transport) throws IOException {
+        this(transport, 0.1, 2.0);
+    }
+
+    /**
+     * Construct the driver.
+     *
+     * <p>Computes {@code Current_LSB = maxCurrent / 32768} and
+     * {@code CAL = int(0.00512 / (Current_LSB × rShunt))}, then writes
+     * the default configuration register and calibration register.
+     *
+     * @param transport  I²C transport bound to the INA226 device address
+     * @param rShunt     shunt resistor value in Ω (e.g. 0.1)
+     * @param maxCurrent maximum expected current in A (e.g. 2.0)
+     * @throws IOException on I²C error
+     */
+    public Ina226Minimal(Transport transport, double rShunt, double maxCurrent) throws IOException {
+        this.transport  = transport;
+        this.currentLsb = maxCurrent / 32768.0;
+        this.cal        = (int) (0.00512 / (currentLsb * rShunt));
+        writeReg(REG_CONFIG, DEFAULT_CONFIG);
+        writeReg(REG_CAL, cal);
+    }
+
+    /**
+     * Read the bus voltage.
+     *
+     * @return bus voltage in V (1.25 mV LSB, unsigned 16-bit)
+     * @throws IOException on I²C error
+     */
+    public double voltage() throws IOException {
+        return readReg(REG_BUS) * 1.25e-3;
+    }
+
+    /**
+     * Read the shunt voltage.
+     *
+     * @return shunt voltage in V (2.5 µV LSB, signed 16-bit)
+     * @throws IOException on I²C error
+     */
+    public double shuntVoltage() throws IOException {
+        return readRegSigned(REG_SHUNT) * 2.5e-6;
+    }
+
+    /**
+     * Read the current through the shunt resistor.
+     *
+     * <p>Requires a valid Calibration register value (written in the constructor).
+     *
+     * @return current in A (signed, Current_LSB per bit)
+     * @throws IOException on I²C error
+     */
+    public double current() throws IOException {
+        return readRegSigned(REG_CURRENT) * currentLsb;
+    }
+
+    /**
+     * Read the calculated power.
+     *
+     * <p>Power = 25 × Current_LSB × raw power register (unsigned).
+     *
+     * @return power in W
+     * @throws IOException on I²C error
+     */
+    public double power() throws IOException {
+        return readReg(REG_POWER) * 25.0 * currentLsb;
+    }
+
+    // ---- low-level helpers ----
+
+    /**
+     * Write a 16-bit value to a register (big-endian, register-pointer protocol).
+     *
+     * @param reg register address
+     * @param val 16-bit value
+     * @throws IOException on I²C error
+     */
+    protected void writeReg(int reg, int val) throws IOException {
+        transport.write(new byte[]{
+                (byte) reg,
+                (byte) (val >> 8),
+                (byte) (val & 0xFF)
+        });
+    }
+
+    /**
+     * Read an unsigned 16-bit value from a register.
+     *
+     * @param reg register address
+     * @return unsigned 16-bit value (0–65535)
+     * @throws IOException on I²C error
+     */
+    protected int readReg(int reg) throws IOException {
+        byte[] b = transport.writeRead(new byte[]{(byte) reg}, 2);
+        return ((b[0] & 0xFF) << 8) | (b[1] & 0xFF);
+    }
+
+    /**
+     * Read a signed 16-bit value from a register.
+     *
+     * @param reg register address
+     * @return signed 16-bit value (-32768–32767)
+     * @throws IOException on I²C error
+     */
+    protected int readRegSigned(int reg) throws IOException {
+        byte[] b = transport.writeRead(new byte[]{(byte) reg}, 2);
+        return (short) (((b[0] & 0xFF) << 8) | (b[1] & 0xFF));
+    }
+}

--- a/jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina3221Full.java
+++ b/jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina3221Full.java
@@ -1,0 +1,371 @@
+package it.uhde.periph.chips.power;
+
+import it.uhde.periph.transport.Transport;
+
+import java.io.IOException;
+
+/**
+ * INA3221 — full driver. Extends {@link Ina3221Minimal} with configuration,
+ * per-channel enable/disable, alert limits, summation, power-valid thresholds,
+ * shutdown/wake, and identification registers.
+ *
+ * <h2>Alert flags</h2>
+ * Reading the Mask/Enable register (via {@link #alertFlags()}) also clears the
+ * latched alert flags. Read it once after a monitoring interval to capture and
+ * clear all pending alerts.
+ *
+ * <h2>Mode constants</h2>
+ * <ul>
+ *   <li>{@link #MODE_POWERDOWN} — power-down (0)</li>
+ *   <li>{@link #MODE_SHUNT_TRIG} — shunt triggered (1)</li>
+ *   <li>{@link #MODE_BUS_TRIG} — bus triggered (2)</li>
+ *   <li>{@link #MODE_SHUNT_BUS_TRIG} — shunt + bus triggered (3)</li>
+ *   <li>{@link #MODE_SHUNT_CONT} — shunt continuous (5)</li>
+ *   <li>{@link #MODE_BUS_CONT} — bus continuous (6)</li>
+ *   <li>{@link #MODE_SHUNT_BUS_CONT} — shunt + bus continuous (7, default)</li>
+ * </ul>
+ */
+public class Ina3221Full extends Ina3221Minimal {
+
+    // ---- Mode constants ----
+    /** Power-down mode (MODE bits = 000). */
+    public static final int MODE_POWERDOWN       = 0;
+    /** Single-shot shunt voltage measurement (MODE bits = 001). */
+    public static final int MODE_SHUNT_TRIG      = 1;
+    /** Single-shot bus voltage measurement (MODE bits = 010). */
+    public static final int MODE_BUS_TRIG        = 2;
+    /** Single-shot shunt and bus voltage measurement (MODE bits = 011). */
+    public static final int MODE_SHUNT_BUS_TRIG  = 3;
+    /** Continuous shunt voltage measurement (MODE bits = 101). */
+    public static final int MODE_SHUNT_CONT      = 5;
+    /** Continuous bus voltage measurement (MODE bits = 110). */
+    public static final int MODE_BUS_CONT        = 6;
+    /** Continuous shunt and bus voltage measurement (MODE bits = 111, default). */
+    public static final int MODE_SHUNT_BUS_CONT  = 7;
+
+    // ---- Mask/Enable bit positions ----
+    /** Critical flag channel 1 (bit 9). */
+    public static final int CF1  = 512;
+    /** Critical flag channel 2 (bit 8). */
+    public static final int CF2  = 256;
+    /** Critical flag channel 3 (bit 7). */
+    public static final int CF3  = 128;
+    /** Summation flag (bit 6). */
+    public static final int SF   = 64;
+    /** Warning flag channel 1 (bit 5). */
+    public static final int WF1  = 32;
+    /** Warning flag channel 2 (bit 4). */
+    public static final int WF2  = 16;
+    /** Warning flag channel 3 (bit 3). */
+    public static final int WF3  = 8;
+    /** Power-valid flag (bit 2). */
+    public static final int PVF  = 4;
+    /** Timing control flag (bit 1). */
+    public static final int TCF  = 2;
+    /** Conversion-ready flag (bit 0). */
+    public static final int CVRF = 1;
+
+    /** Last user-configured MODE bits (3 bits); saved so wake() can restore them. */
+    private int savedMode = MODE_SHUNT_BUS_CONT;
+
+    /**
+     * Construct the full driver with a uniform shunt resistance for all channels.
+     *
+     * @param transport I²C transport bound to the INA3221 device address
+     * @param rShunt    shunt resistance in Ω applied to all three channels
+     */
+    public Ina3221Full(Transport transport, double rShunt) {
+        super(transport, rShunt);
+    }
+
+    /**
+     * Construct the full driver with per-channel shunt resistances.
+     *
+     * @param transport I²C transport bound to the INA3221 device address
+     * @param rShunts   shunt resistances in Ω for channels 1, 2, and 3
+     */
+    public Ina3221Full(Transport transport, double[] rShunts) {
+        super(transport, rShunts);
+    }
+
+    /**
+     * Construct the full driver with the default shunt resistance (0.1 Ω).
+     *
+     * @param transport I²C transport bound to the INA3221 device address
+     */
+    public Ina3221Full(Transport transport) {
+        super(transport);
+    }
+
+    /**
+     * Write the configuration register, preserving the channel-enable bits.
+     *
+     * <p>The channel-enable bits (CH1en, CH2en, CH3en) in the current
+     * configuration are read first and OR-ed into the new value so that
+     * calling configure() does not inadvertently disable channels.
+     *
+     * @param avg    averaging mode (0–7): 0=1, 1=4, 2=16, 3=64, 4=128, 5=256, 6=512, 7=1024 samples
+     * @param vbusCt bus voltage conversion time (0–7): 0=140 µs … 7=8.244 ms
+     * @param vshCt  shunt voltage conversion time (0–7): 0=140 µs … 7=8.244 ms
+     * @param mode   operating mode (0–7); use MODE_* constants
+     * @throws IOException on I²C error
+     */
+    public void configure(int avg, int vbusCt, int vshCt, int mode) throws IOException {
+        savedMode = mode & 0x07;
+        int current = readReg(REG_CONFIG);
+        int channelBits = current & 0x7000; // CH1en[14], CH2en[13], CH3en[12]
+        int val = channelBits
+                | ((avg   & 0x07) << 9)
+                | ((vbusCt & 0x07) << 6)
+                | ((vshCt  & 0x07) << 3)
+                | (mode    & 0x07);
+        writeReg(REG_CONFIG, val);
+    }
+
+    /**
+     * Enable or disable a channel.
+     *
+     * <p>Reads the current configuration, toggles the CHnen bit, and writes
+     * the modified value back.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @param enabled {@code true} to enable, {@code false} to disable
+     * @throws IOException              on I²C error
+     * @throws IllegalArgumentException if channel is not 1, 2, or 3
+     */
+    public void enableChannel(int channel, boolean enabled) throws IOException {
+        checkChannel(channel);
+        // Channel enable bits: CH1en=bit14, CH2en=bit13, CH3en=bit12
+        int bit = 1 << (15 - channel);
+        int cfg = readReg(REG_CONFIG);
+        if (enabled) cfg |= bit;
+        else         cfg &= ~bit;
+        writeReg(REG_CONFIG, cfg & 0xFFFF);
+    }
+
+    /**
+     * Read whether a channel is currently enabled.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @return {@code true} if the channel enable bit is set
+     * @throws IOException              on I²C error
+     * @throws IllegalArgumentException if channel is not 1, 2, or 3
+     */
+    public boolean channelEnabled(int channel) throws IOException {
+        checkChannel(channel);
+        int bit = 1 << (15 - channel);
+        return (readReg(REG_CONFIG) & bit) != 0;
+    }
+
+    /**
+     * Read the Conversion Ready Flag (CVRF) from the Mask/Enable register.
+     *
+     * <p>CVRF is set after a complete conversion cycle. Reading the Mask/Enable
+     * register clears the latched alert flags but does not affect CVRF.
+     *
+     * @return {@code true} if a conversion cycle has completed since the last read
+     * @throws IOException on I²C error
+     */
+    public boolean conversionReady() throws IOException {
+        return (readReg(REG_MASK_ENABLE) & CVRF) != 0;
+    }
+
+    /**
+     * Set the critical alert limit for a channel.
+     *
+     * <p>The alert fires when the shunt voltage magnitude exceeds this limit.
+     * The value is encoded as a left-aligned 13-bit signed integer (same format
+     * as the shunt voltage register).
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @param limitV  shunt voltage threshold in V (positive; both polarities are checked by hardware)
+     * @throws IOException              on I²C error
+     * @throws IllegalArgumentException if channel is not 1, 2, or 3
+     */
+    public void setCriticalAlert(int channel, double limitV) throws IOException {
+        checkChannel(channel);
+        int reg = REG_CH1_CRIT + (channel - 1) * 2;
+        writeReg(reg, encodeAlertLimit(limitV));
+    }
+
+    /**
+     * Set the warning alert limit for a channel.
+     *
+     * <p>The alert fires when the shunt voltage magnitude exceeds this limit.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @param limitV  shunt voltage threshold in V (positive)
+     * @throws IOException              on I²C error
+     * @throws IllegalArgumentException if channel is not 1, 2, or 3
+     */
+    public void setWarningAlert(int channel, double limitV) throws IOException {
+        checkChannel(channel);
+        int reg = REG_CH1_WARN + (channel - 1) * 2;
+        writeReg(reg, encodeAlertLimit(limitV));
+    }
+
+    /**
+     * Read and clear the Mask/Enable register (alert flags).
+     *
+     * <p>Reading this register clears all latched alert flag bits. The returned
+     * value can be inspected against the CF1, CF2, CF3, SF, WF1, WF2, WF3, PVF,
+     * TCF, and CVRF constants.
+     *
+     * @return the raw 16-bit Mask/Enable register value
+     * @throws IOException on I²C error
+     */
+    public int alertFlags() throws IOException {
+        return readReg(REG_MASK_ENABLE);
+    }
+
+    /**
+     * Set the summation channel selection (SCC) bits and the summation limit.
+     *
+     * <p>The SCC bits in the Mask/Enable register determine which channels
+     * contribute to the shunt-voltage sum. The sum limit is written to register
+     * 0x0E using the same left-aligned 14-bit signed format as the sum register.
+     *
+     * @param channels  array of channel numbers to include in the sum (values 1–3)
+     * @param limitV    summation shunt voltage limit in V
+     * @throws IOException              on I²C error
+     * @throws IllegalArgumentException if any channel value is not 1, 2, or 3
+     */
+    public void setSummationChannels(int[] channels, double limitV) throws IOException {
+        // SCC bits in Mask/Enable: SCC1=bit14, SCC2=bit13, SCC3=bit12
+        int me = readReg(REG_MASK_ENABLE) & 0x0FFF; // clear existing SCC bits
+        for (int ch : channels) {
+            checkChannel(ch);
+            me |= (1 << (15 - ch));
+        }
+        writeReg(REG_MASK_ENABLE, me & 0xFFFF);
+        // Sum limit uses left-aligned 14-bit signed format (shift left by 1)
+        int raw = ((int) Math.round(limitV / 40e-6)) & 0x7FFE;
+        writeReg(REG_SV_SUM_LIMIT, (raw << 1) & 0xFFFE);
+    }
+
+    /**
+     * Read the shunt-voltage sum register.
+     *
+     * <p>The register holds a 14-bit signed value, left-aligned by 1 bit.
+     * The LSB is 20 µV (40 µV × 0.5 due to the extra shift).
+     *
+     * @return shunt-voltage sum in V
+     * @throws IOException on I²C error
+     */
+    public double summationValue() throws IOException {
+        int raw = readReg(REG_SV_SUM);
+        // 14-bit signed, left-aligned by 1 → arithmetic right-shift by 1
+        return ((short) raw >> 1) * 40e-6;
+    }
+
+    /**
+     * Set the power-valid upper and lower voltage thresholds.
+     *
+     * <p>The power-valid flag (PVF) is set when all enabled bus voltages are
+     * between lowerV and upperV. Thresholds are 12-bit unsigned, left-aligned
+     * by 3 bits (8 mV LSB, same as bus voltage).
+     *
+     * @param upperV upper threshold in V (register 0x10, reset = 10.000 V)
+     * @param lowerV lower threshold in V (register 0x11, reset = 9.000 V)
+     * @throws IOException on I²C error
+     */
+    public void setPowerValidLimits(double upperV, double lowerV) throws IOException {
+        writeReg(REG_PV_UPPER, ((int) Math.round(upperV / 8e-3) & 0x1FFF) << 3);
+        writeReg(REG_PV_LOWER, ((int) Math.round(lowerV / 8e-3) & 0x1FFF) << 3);
+    }
+
+    /**
+     * Read the Power Valid Flag (PVF) from the Mask/Enable register.
+     *
+     * <p>PVF is set when all enabled bus voltages are within the power-valid
+     * window set by {@link #setPowerValidLimits(double, double)}.
+     *
+     * @return {@code true} if all enabled channels are within the power-valid window
+     * @throws IOException on I²C error
+     */
+    public boolean powerValid() throws IOException {
+        return (readReg(REG_MASK_ENABLE) & PVF) != 0;
+    }
+
+    /**
+     * Put the device into power-down mode (MODE = 000).
+     *
+     * <p>The current MODE setting is saved so that {@link #wake()} can restore it.
+     *
+     * @throws IOException on I²C error
+     */
+    public void shutdown() throws IOException {
+        int cfg = readReg(REG_CONFIG);
+        savedMode = cfg & 0x07;
+        writeReg(REG_CONFIG, (cfg & 0xFFF8) | MODE_POWERDOWN);
+    }
+
+    /**
+     * Restore the operating mode saved by the last call to {@link #shutdown()} or
+     * {@link #configure(int, int, int, int)}.
+     *
+     * <p>If neither method has been called, the default continuous shunt+bus mode
+     * (7) is restored.
+     *
+     * @throws IOException on I²C error
+     */
+    public void wake() throws IOException {
+        int cfg = readReg(REG_CONFIG);
+        writeReg(REG_CONFIG, (cfg & 0xFFF8) | (savedMode & 0x07));
+    }
+
+    /**
+     * Trigger a software reset by setting the RST bit, then restore the user
+     * configuration by writing the saved MODE back into the configuration register.
+     *
+     * <p>After reset, the chip returns to its hardware defaults. The previously
+     * saved mode is written back so the chip resumes normal operation.
+     *
+     * @throws IOException on I²C error
+     */
+    public void reset() throws IOException {
+        // RST bit is bit 15 of configuration register
+        writeReg(REG_CONFIG, 0x8000);
+        // The reset value is 0x7127; restore saved mode into MODE bits
+        int defaults = 0x7127;
+        writeReg(REG_CONFIG, (defaults & 0xFFF8) | (savedMode & 0x07));
+    }
+
+    /**
+     * Read the Manufacturer ID register.
+     *
+     * <p>Expected value: 0x5449 ("TI").
+     *
+     * @return manufacturer ID
+     * @throws IOException on I²C error
+     */
+    public int manufacturerId() throws IOException {
+        return readReg(REG_MANUFACTURER);
+    }
+
+    /**
+     * Read the Die ID register.
+     *
+     * <p>Expected value: 0x3220.
+     *
+     * @return die ID
+     * @throws IOException on I²C error
+     */
+    public int dieId() throws IOException {
+        return readReg(REG_DIE_ID);
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Encode a shunt voltage alert limit into the left-aligned 13-bit register format.
+     *
+     * @param limitV threshold in V
+     * @return encoded 16-bit register value
+     */
+    private static int encodeAlertLimit(double limitV) {
+        return ((int) Math.round(limitV / 40e-6) << 3) & 0xFFF8;
+    }
+}

--- a/jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina3221Minimal.java
+++ b/jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina3221Minimal.java
@@ -1,0 +1,202 @@
+package it.uhde.periph.chips.power;
+
+import it.uhde.periph.transport.Transport;
+
+import java.io.IOException;
+
+/**
+ * INA3221 — 3-channel, high-side measurement, shunt and bus voltage monitor
+ * with I²C interface (minimal driver).
+ *
+ * <p>Measures bus voltage and shunt voltage on up to three independent channels.
+ * Current and power are computed in software from the shunt voltage and the
+ * per-channel shunt resistance supplied at construction time. There is no
+ * calibration register; all scaling is done in the driver.
+ *
+ * <p>The constructor does not write any registers — the chip's hardware reset
+ * default (configuration register 0x7127: all channels enabled, 1-sample
+ * averaging, 1.1 ms conversion, continuous shunt+bus mode) is suitable for
+ * immediate use.
+ *
+ * <p>Default I²C address: 0x40 (A0=GND, A1=GND).
+ */
+public class Ina3221Minimal {
+
+    /** I²C register addresses. */
+    protected static final int REG_CONFIG        = 0x00;
+    protected static final int REG_CH1_SHUNT_V   = 0x01;
+    protected static final int REG_CH1_BUS_V     = 0x02;
+    protected static final int REG_CH2_SHUNT_V   = 0x03;
+    protected static final int REG_CH2_BUS_V     = 0x04;
+    protected static final int REG_CH3_SHUNT_V   = 0x05;
+    protected static final int REG_CH3_BUS_V     = 0x06;
+    protected static final int REG_CH1_CRIT      = 0x07;
+    protected static final int REG_CH1_WARN      = 0x08;
+    protected static final int REG_CH2_CRIT      = 0x09;
+    protected static final int REG_CH2_WARN      = 0x0A;
+    protected static final int REG_CH3_CRIT      = 0x0B;
+    protected static final int REG_CH3_WARN      = 0x0C;
+    protected static final int REG_SV_SUM        = 0x0D;
+    protected static final int REG_SV_SUM_LIMIT  = 0x0E;
+    protected static final int REG_MASK_ENABLE   = 0x0F;
+    protected static final int REG_PV_UPPER      = 0x10;
+    protected static final int REG_PV_LOWER      = 0x11;
+    protected static final int REG_MANUFACTURER  = 0xFE;
+    protected static final int REG_DIE_ID        = 0xFF;
+
+    /** Shunt voltage register base addresses indexed by channel (1-based, index 1–3). */
+    private static final int[] SHUNT_BASE = {0, 0x01, 0x03, 0x05};
+
+    /** Bus voltage register base addresses indexed by channel (1-based, index 1–3). */
+    private static final int[] BUS_BASE   = {0, 0x02, 0x04, 0x06};
+
+    protected final Transport transport;
+
+    /** Per-channel shunt resistances in Ω (index 0 = channel 1). */
+    protected final double[] rShunts;
+
+    /**
+     * Construct the driver with a uniform shunt resistance for all three channels.
+     *
+     * <p>No registers are written; the hardware reset defaults are used.
+     *
+     * @param transport I²C transport bound to the INA3221 device address
+     * @param rShunt    shunt resistance in Ω applied to all three channels (e.g. 0.1)
+     */
+    public Ina3221Minimal(Transport transport, double rShunt) {
+        this.transport = transport;
+        this.rShunts   = new double[]{rShunt, rShunt, rShunt};
+    }
+
+    /**
+     * Construct the driver with per-channel shunt resistances.
+     *
+     * <p>No registers are written; the hardware reset defaults are used.
+     *
+     * @param transport I²C transport bound to the INA3221 device address
+     * @param rShunts   shunt resistances in Ω for channels 1, 2, and 3 (array length must be 3)
+     * @throws IllegalArgumentException if {@code rShunts} does not have exactly 3 elements
+     */
+    public Ina3221Minimal(Transport transport, double[] rShunts) {
+        if (rShunts == null || rShunts.length != 3)
+            throw new IllegalArgumentException("rShunts must have exactly 3 elements");
+        this.transport = transport;
+        this.rShunts   = rShunts.clone();
+    }
+
+    /**
+     * Construct the driver with the default shunt resistance (0.1 Ω) for all channels.
+     *
+     * @param transport I²C transport bound to the INA3221 device address
+     */
+    public Ina3221Minimal(Transport transport) {
+        this(transport, 0.1);
+    }
+
+    /**
+     * Read the bus voltage for a channel.
+     *
+     * <p>Reads the left-aligned 12-bit unsigned bus voltage register, right-shifts
+     * by 3, and multiplies by the 8 mV LSB.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @return bus voltage in V
+     * @throws IOException              on I²C error
+     * @throws IllegalArgumentException if channel is not 1, 2, or 3
+     */
+    public double voltage(int channel) throws IOException {
+        checkChannel(channel);
+        int raw = readReg(BUS_BASE[channel]);
+        return (raw >> 3) * 8e-3;
+    }
+
+    /**
+     * Read the shunt voltage for a channel.
+     *
+     * <p>Reads the left-aligned 13-bit signed shunt voltage register, right-shifts
+     * by 3 (arithmetic), and multiplies by the 40 µV LSB.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @return shunt voltage in V (may be negative)
+     * @throws IOException              on I²C error
+     * @throws IllegalArgumentException if channel is not 1, 2, or 3
+     */
+    public double shuntVoltage(int channel) throws IOException {
+        checkChannel(channel);
+        int raw = readReg(SHUNT_BASE[channel]);
+        return ((short) raw >> 3) * 40e-6;
+    }
+
+    /**
+     * Compute the current through the shunt resistor for a channel.
+     *
+     * <p>Current = shuntVoltage / rShunt[channel]. The shunt resistance is
+     * the value supplied at construction time.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @return current in A (may be negative for reverse flow)
+     * @throws IOException              on I²C error
+     * @throws IllegalArgumentException if channel is not 1, 2, or 3
+     */
+    public double current(int channel) throws IOException {
+        checkChannel(channel);
+        return shuntVoltage(channel) / rShunts[channel - 1];
+    }
+
+    /**
+     * Compute the power consumed on a channel.
+     *
+     * <p>Power = busVoltage × current.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @return power in W
+     * @throws IOException              on I²C error
+     * @throws IllegalArgumentException if channel is not 1, 2, or 3
+     */
+    public double power(int channel) throws IOException {
+        checkChannel(channel);
+        return voltage(channel) * current(channel);
+    }
+
+    // -------------------------------------------------------------------------
+    // Protected helpers (shared with Ina3221Full)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Read a 16-bit big-endian register.
+     *
+     * @param reg register address
+     * @return raw unsigned 16-bit value
+     * @throws IOException on I²C error
+     */
+    protected int readReg(int reg) throws IOException {
+        byte[] b = transport.writeRead(new byte[]{(byte) reg}, 2);
+        return ((b[0] & 0xFF) << 8) | (b[1] & 0xFF);
+    }
+
+    /**
+     * Write a 16-bit big-endian register.
+     *
+     * @param reg register address
+     * @param val 16-bit value to write
+     * @throws IOException on I²C error
+     */
+    protected void writeReg(int reg, int val) throws IOException {
+        transport.write(new byte[]{
+                (byte) reg,
+                (byte) ((val >> 8) & 0xFF),
+                (byte) (val & 0xFF)
+        });
+    }
+
+    /**
+     * Validate that a channel number is 1, 2, or 3.
+     *
+     * @param channel channel number to validate
+     * @throws IllegalArgumentException if channel is not 1, 2, or 3
+     */
+    protected static void checkChannel(int channel) {
+        if (channel < 1 || channel > 3)
+            throw new IllegalArgumentException("channel must be 1-3, got: " + channel);
+    }
+}

--- a/jvm/periph-java/src/main/java/it/uhde/periph/chips/pressure/Bmp180Full.java
+++ b/jvm/periph-java/src/main/java/it/uhde/periph/chips/pressure/Bmp180Full.java
@@ -1,0 +1,132 @@
+package it.uhde.periph.chips.pressure;
+
+import it.uhde.periph.transport.Transport;
+
+import java.io.IOException;
+
+/**
+ * BMP180 — full driver. Extends {@link Bmp180Minimal} with oversampling control,
+ * altitude calculation, sea-level pressure derivation, chip ID read-back, and
+ * soft reset.
+ *
+ * <h2>OSS constants</h2>
+ * {@link #OSS_ULP}, {@link #OSS_STANDARD}, {@link #OSS_HIGH_RES}, {@link #OSS_ULTRA_HIGH_RES}
+ *
+ * <h2>Altitude formula</h2>
+ * {@code altitude_m = 44330.0 × (1.0 − (pressure_hPa / seaLevelHpa)^(1/5.255))}
+ */
+public class Bmp180Full extends Bmp180Minimal {
+
+    /** Ultra-low-power mode: OSS = 0 (1 sample, ~4.5 ms, 3 µA RMS). */
+    public static final int OSS_ULP             = 0;
+    /** Standard mode: OSS = 1 (2 samples, ~7.5 ms, 5 µA RMS). */
+    public static final int OSS_STANDARD        = 1;
+    /** High-resolution mode: OSS = 2 (4 samples, ~13.5 ms, 7 µA RMS). */
+    public static final int OSS_HIGH_RES        = 2;
+    /** Ultra-high-resolution mode: OSS = 3 (8 samples, ~25.5 ms, 12 µA RMS). */
+    public static final int OSS_ULTRA_HIGH_RES  = 3;
+
+    /** Sea-level pressure in hPa used when none is supplied. */
+    private static final double DEFAULT_SEA_LEVEL_HPA = 1013.25;
+
+    /**
+     * Construct the full driver, verify chip ID, and load calibration.
+     *
+     * @param transport I²C transport bound to address 0x77
+     * @throws IOException on I²C error, wrong chip ID, or invalid calibration
+     */
+    public Bmp180Full(Transport transport) throws IOException {
+        super(transport);
+    }
+
+    /**
+     * Read the current oversampling setting.
+     *
+     * @return OSS value (0–3)
+     */
+    public int oversampling() {
+        return oss;
+    }
+
+    /**
+     * Set the oversampling setting.
+     *
+     * @param oss oversampling value (0–3); use the {@code OSS_*} constants
+     * @throws IllegalArgumentException if oss is outside [0, 3]
+     */
+    public void setOversampling(int oss) {
+        if (oss < 0 || oss > 3) {
+            throw new IllegalArgumentException("OSS must be 0–3, got: " + oss);
+        }
+        this.oss = oss;
+    }
+
+    /**
+     * Compute altitude using the default sea-level pressure (1013.25 hPa).
+     *
+     * @return altitude in m
+     * @throws IOException on I²C error
+     */
+    public double altitude() throws IOException {
+        return altitude(DEFAULT_SEA_LEVEL_HPA);
+    }
+
+    /**
+     * Compute altitude for a given sea-level reference pressure.
+     *
+     * <p>Uses the barometric formula:
+     * {@code altitude_m = 44330 × (1 − (pressure / seaLevelHpa)^(1/5.255))}
+     *
+     * @param seaLevelHpa reference sea-level pressure in hPa
+     * @return altitude in m
+     * @throws IOException on I²C error
+     */
+    public double altitude(double seaLevelHpa) throws IOException {
+        double p = pressure();
+        return 44330.0 * (1.0 - Math.pow(p / seaLevelHpa, 1.0 / 5.255));
+    }
+
+    /**
+     * Back-calculate the sea-level pressure from the current reading and a
+     * known altitude.
+     *
+     * @param altitudeM known altitude in m
+     * @return sea-level pressure in hPa
+     * @throws IOException on I²C error
+     */
+    public double seaLevelPressure(double altitudeM) throws IOException {
+        double p = pressure();
+        return p / Math.pow(1.0 - altitudeM / 44330.0, 5.255);
+    }
+
+    /**
+     * Read the chip ID register (0xD0).
+     *
+     * <p>Expected value is 0x55 for BMP180.
+     *
+     * @return chip ID byte
+     * @throws IOException on I²C error
+     */
+    public int chipId() throws IOException {
+        byte[] b = transport.writeRead(new byte[]{(byte) REG_ID}, 1);
+        return b[0] & 0xFF;
+    }
+
+    /**
+     * Perform a soft reset and reload calibration.
+     *
+     * <p>Writes 0xB6 to register 0xE0, waits 15 ms for the chip to complete its
+     * power-on sequence, then re-reads and validates the calibration EEPROM.
+     *
+     * @throws IOException on I²C error or invalid calibration after reset
+     */
+    public void reset() throws IOException {
+        transport.write(new byte[]{(byte) REG_SOFT_RST, (byte) 0xB6});
+        try {
+            Thread.sleep(15);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        readCalibration();
+    }
+}

--- a/jvm/periph-java/src/main/java/it/uhde/periph/chips/pressure/Bmp180Minimal.java
+++ b/jvm/periph-java/src/main/java/it/uhde/periph/chips/pressure/Bmp180Minimal.java
@@ -1,0 +1,206 @@
+package it.uhde.periph.chips.pressure;
+
+import it.uhde.periph.transport.Transport;
+
+import java.io.IOException;
+
+/**
+ * BMP180 — digital barometric pressure and temperature sensor (minimal driver).
+ *
+ * <p>Reads temperature and pressure via I²C using Bosch's integer compensation
+ * algorithm. Calibration coefficients are loaded from the chip's EEPROM during
+ * construction and sanity-checked. The chip ID register is verified to be 0x55.
+ *
+ * <p>Fixed I²C address: 0x77 (hardware-defined, not configurable).
+ *
+ * <p>Default oversampling setting (OSS): 0 (ultra-low-power).
+ */
+public class Bmp180Minimal {
+
+    // Register addresses
+    protected static final int REG_CAL_START = 0xAA;
+    protected static final int REG_ID        = 0xD0;
+    protected static final int REG_SOFT_RST  = 0xE0;
+    protected static final int REG_CTRL_MEAS = 0xF4;
+    protected static final int REG_OUT_MSB   = 0xF6;
+
+    // Command bytes
+    protected static final int CMD_TEMP     = 0x2E;
+    protected static final int CMD_PRES_OSS = 0x34;
+
+    // Chip ID
+    protected static final int CHIP_ID = 0x55;
+
+    protected final Transport transport;
+
+    // Calibration coefficients
+    protected int   AC1, AC2, AC3;
+    protected int   AC4, AC5, AC6;   // unsigned — stored as int, mask with 0xFFFF where needed
+    protected int   B1,  B2;
+    protected int   MB,  MC,  MD;
+
+    /** Current oversampling setting (0–3). */
+    protected int oss = 0;
+
+    /**
+     * Construct the driver, verify the chip ID, and load calibration data.
+     *
+     * @param transport I²C transport bound to address 0x77
+     * @throws IOException on I²C error, wrong chip ID, or invalid calibration
+     */
+    public Bmp180Minimal(Transport transport) throws IOException {
+        this.transport = transport;
+
+        // Verify chip ID
+        byte[] id = transport.writeRead(new byte[]{(byte) REG_ID}, 1);
+        if ((id[0] & 0xFF) != CHIP_ID) {
+            throw new IOException(
+                    "BMP180 not found: expected chip ID 0x55, got 0x"
+                    + Integer.toHexString(id[0] & 0xFF));
+        }
+
+        readCalibration();
+    }
+
+    /**
+     * Read and unpack the 22-byte calibration block from EEPROM (0xAA–0xBF).
+     *
+     * @throws IOException on I²C error or invalid calibration data
+     */
+    protected void readCalibration() throws IOException {
+        byte[] cal = transport.writeRead(new byte[]{(byte) REG_CAL_START}, 22);
+
+        AC1 = (short) (((cal[0]  & 0xFF) << 8) | (cal[1]  & 0xFF));
+        AC2 = (short) (((cal[2]  & 0xFF) << 8) | (cal[3]  & 0xFF));
+        AC3 = (short) (((cal[4]  & 0xFF) << 8) | (cal[5]  & 0xFF));
+        AC4 =          ((cal[6]  & 0xFF) << 8)  | (cal[7]  & 0xFF);   // uint16
+        AC5 =          ((cal[8]  & 0xFF) << 8)  | (cal[9]  & 0xFF);   // uint16
+        AC6 =          ((cal[10] & 0xFF) << 8)  | (cal[11] & 0xFF);   // uint16
+        B1  = (short) (((cal[12] & 0xFF) << 8) | (cal[13] & 0xFF));
+        B2  = (short) (((cal[14] & 0xFF) << 8) | (cal[15] & 0xFF));
+        MB  = (short) (((cal[16] & 0xFF) << 8) | (cal[17] & 0xFF));
+        MC  = (short) (((cal[18] & 0xFF) << 8) | (cal[19] & 0xFF));
+        MD  = (short) (((cal[20] & 0xFF) << 8) | (cal[21] & 0xFF));
+
+        checkCalibration();
+    }
+
+    /**
+     * Sanity-check: no coefficient may be 0x0000 or 0xFFFF.
+     *
+     * @throws IOException if any coefficient is 0x0000 or 0xFFFF
+     */
+    protected void checkCalibration() throws IOException {
+        int[] raw16 = {
+            AC1 & 0xFFFF, AC2 & 0xFFFF, AC3 & 0xFFFF,
+            AC4 & 0xFFFF, AC5 & 0xFFFF, AC6 & 0xFFFF,
+            B1  & 0xFFFF, B2  & 0xFFFF,
+            MB  & 0xFFFF, MC  & 0xFFFF, MD  & 0xFFFF
+        };
+        String[] names = {"AC1","AC2","AC3","AC4","AC5","AC6","B1","B2","MB","MC","MD"};
+        for (int i = 0; i < raw16.length; i++) {
+            if (raw16[i] == 0x0000 || raw16[i] == 0xFFFF) {
+                throw new IOException(
+                        "BMP180 calibration invalid: " + names[i]
+                        + " = 0x" + Integer.toHexString(raw16[i]));
+            }
+        }
+    }
+
+    /**
+     * Trigger a temperature measurement and return the raw ADC value (UT).
+     *
+     * @return unsigned 16-bit raw temperature
+     * @throws IOException on I²C error
+     */
+    protected int readRawTemperature() throws IOException {
+        transport.write(new byte[]{(byte) REG_CTRL_MEAS, (byte) CMD_TEMP});
+        try { Thread.sleep(5); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        byte[] b = transport.writeRead(new byte[]{(byte) REG_OUT_MSB}, 2);
+        return ((b[0] & 0xFF) << 8) | (b[1] & 0xFF);
+    }
+
+    /**
+     * Trigger a pressure measurement and return the raw ADC value (UP).
+     *
+     * @param ossMode oversampling setting (0–3)
+     * @return raw pressure ADC value (shifted by oss)
+     * @throws IOException on I²C error
+     */
+    protected long readRawPressure(int ossMode) throws IOException {
+        transport.write(new byte[]{(byte) REG_CTRL_MEAS, (byte) (CMD_PRES_OSS | (ossMode << 6))});
+        try { Thread.sleep(ossMode * 10L + 5L); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        byte[] b = transport.writeRead(new byte[]{(byte) REG_OUT_MSB}, 3);
+        long raw = (((long)(b[0] & 0xFF) << 16) | ((long)(b[1] & 0xFF) << 8) | (b[2] & 0xFF));
+        return raw >> (8 - ossMode);
+    }
+
+    /**
+     * Compute B5 from a raw temperature value (UT).
+     *
+     * @param UT raw temperature ADC value
+     * @return B5 (shared intermediate used by both temperature and pressure compensation)
+     */
+    protected long computeB5(int UT) {
+        long X1 = ((long)(UT - AC6) * AC5) >> 15;
+        long X2 = ((long)MC << 11) / (X1 + MD);
+        return X1 + X2;
+    }
+
+    /**
+     * Read the temperature.
+     *
+     * <p>Triggers a temperature measurement, runs Bosch integer compensation,
+     * and returns the result in degrees Celsius.
+     *
+     * @return temperature in °C
+     * @throws IOException on I²C error
+     */
+    public double temperature() throws IOException {
+        int  UT = readRawTemperature();
+        long B5 = computeB5(UT);
+        long T  = (B5 + 8) >> 4;
+        return T / 10.0;
+    }
+
+    /**
+     * Read the pressure.
+     *
+     * <p>Re-reads temperature internally to refresh B5, then triggers a pressure
+     * measurement. Runs Bosch integer compensation and returns the result in hPa.
+     *
+     * @return pressure in hPa
+     * @throws IOException on I²C error
+     */
+    public double pressure() throws IOException {
+        int  UT = readRawTemperature();
+        long B5 = computeB5(UT);
+        long UP = readRawPressure(oss);
+
+        long B6 = B5 - 4000;
+        long X1 = (B2 * ((B6 * B6) >> 12)) >> 11;
+        long X2 = (AC2 * B6) >> 11;
+        long X3 = X1 + X2;
+        long B3 = (((AC1 * 4L + X3) << oss) + 2) >> 2;
+
+        X1 = (AC3 * B6) >> 13;
+        X2 = (B1 * ((B6 * B6) >> 12)) >> 16;
+        X3 = ((X1 + X2) + 2) >> 2;
+        long B4 = ((long) AC4 * (X3 + 32768L)) >> 15;
+        long B7 = (UP - B3) * (50000L >> oss);
+
+        long p;
+        if (B7 < 0x80000000L) {
+            p = (B7 * 2) / B4;
+        } else {
+            p = (B7 / B4) * 2;
+        }
+
+        X1 = (p >> 8) * (p >> 8);
+        X1 = (X1 * 3038) >> 16;
+        X2 = (-7357 * p) >> 16;
+        p  = p + ((X1 + X2 + 3791) >> 4);
+
+        return p / 100.0;
+    }
+}

--- a/jvm/periph-java/src/main/java/module-info.java
+++ b/jvm/periph-java/src/main/java/module-info.java
@@ -1,4 +1,6 @@
 module it.uhde.periph {
     exports it.uhde.periph.chips.adc_dac;
+    exports it.uhde.periph.chips.power;
+    exports it.uhde.periph.chips.pressure;
     requires it.uhde.periph.transport;
 }

--- a/jvm/periph-java/src/main/java/module-info.java
+++ b/jvm/periph-java/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module it.uhde.periph {
+    exports it.uhde.periph.chips.adc_dac;
+    requires it.uhde.periph.transport;
+}

--- a/jvm/periph-kotlin/pom.xml
+++ b/jvm/periph-kotlin/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it.uhde</groupId>
+        <artifactId>periph</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>periph-kotlin</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>it.uhde</groupId>
+            <artifactId>periph-transport</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals><goal>compile</goal></goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals><goal>test-compile</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/adc_dac/Mcp4725Full.kt
+++ b/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/adc_dac/Mcp4725Full.kt
@@ -1,0 +1,136 @@
+package it.uhde.periph.chips.adc_dac
+
+import it.uhde.periph.transport.Transport
+import kotlin.math.roundToInt
+
+/**
+ * MCP4725 — full driver. Extends [Mcp4725Minimal] with EEPROM persistence,
+ * power-down control, read-back, and General Call commands (reset / wake-up).
+ *
+ * General Call commands ([reset], [wakeUp]) require a second transport bound to
+ * address 0x00. Pass `null` to disable those methods.
+ *
+ * ## EEPROM write timing
+ * The EEPROM write takes up to 50 ms. New write commands are silently ignored
+ * while RDY/BSY is low. Poll [isEepromReady] or wait 50 ms before issuing a
+ * second EEPROM write.
+ */
+class Mcp4725Full(
+    transport: Transport,
+    private val generalCall: Transport?
+) : Mcp4725Minimal(transport) {
+
+    /**
+     * Read-back state of the MCP4725.
+     *
+     * @property code current DAC register value (0–4095)
+     * @property voltageFraction DAC register value as fraction of V_DD (code / 4095.0)
+     * @property powerDown current power-down mode of the DAC register (0–3)
+     * @property eepromCode EEPROM-stored DAC value (0–4095)
+     * @property eepromPowerDown EEPROM-stored power-down mode (0–3)
+     * @property eepromReady true when EEPROM write is complete (RDY/BSY = 1)
+     */
+    data class ReadResult(
+        val code: Int,
+        val voltageFraction: Double,
+        val powerDown: Int,
+        val eepromCode: Int,
+        val eepromPowerDown: Int,
+        val eepromReady: Boolean
+    )
+
+    /**
+     * Write fraction to both the DAC register and EEPROM.
+     *
+     * @param fraction target output level, 0.0–1.0
+     */
+    fun setVoltageEeprom(fraction: Double) {
+        setRawEeprom((fraction.coerceIn(0.0, 1.0) * 4095).roundToInt())
+    }
+
+    /**
+     * Write a raw 12-bit code to both the DAC register and EEPROM.
+     *
+     * The value persists across power cycles. Wait up to 50 ms before
+     * issuing another EEPROM write.
+     *
+     * @param code 12-bit DAC value (0–4095)
+     */
+    fun setRawEeprom(code: Int) {
+        val c = code.coerceIn(0, 4095)
+        lastCode = c
+        // Write DAC + EEPROM: C2=0 C1=1 C0=1 → byte1=0x60 (normal mode)
+        transport.write(byteArrayOf(
+            0x60,
+            ((c shr 4) and 0xFF).toByte(),
+            ((c shl 4) and 0xF0).toByte()
+        ))
+    }
+
+    /**
+     * Read the current state of the device (5-byte read response).
+     *
+     * @return snapshot of DAC register, EEPROM, power-down, and ready flag
+     */
+    fun read(): ReadResult {
+        val b = transport.read(5)
+        val eepromReady = (b[0].toInt() and 0x80) != 0
+        val powerDown   = (b[0].toInt() shr 2) and 0x03
+        val code        = ((b[1].toInt() and 0xFF) shl 4) or ((b[2].toInt() and 0xFF) shr 4)
+        val eepromPD    = (b[3].toInt() shr 5) and 0x03
+        val eepromCode  = ((b[3].toInt() and 0x0F) shl 8) or (b[4].toInt() and 0xFF)
+        return ReadResult(code, code / 4095.0, powerDown, eepromCode, eepromPD, eepromReady)
+    }
+
+    /**
+     * Enter or exit power-down mode using a Fast Write.
+     *
+     * The last-written DAC code is preserved so the output resumes at the same
+     * level when mode 0 is selected again.
+     *
+     * @param mode 0 = normal, 1 = 1 kΩ to GND, 2 = 100 kΩ to GND, 3 = 500 kΩ to GND
+     */
+    fun setPowerDown(mode: Int) {
+        val m = mode.coerceIn(0, 3)
+        // Fast Write with PD bits set: [0 0 PD1 PD0 D11-D8] [D7-D0]
+        transport.write(byteArrayOf(
+            (((m and 0x03) shl 4) or ((lastCode shr 8) and 0x0F)).toByte(),
+            (lastCode and 0xFF).toByte()
+        ))
+    }
+
+    /**
+     * Send General Call Wake-Up (address 0x00, command 0x09).
+     *
+     * Clears the power-down bits in the DAC register of all MCP47xx devices
+     * on the bus that support General Call.
+     *
+     * @throws IllegalStateException if no General Call transport was provided
+     */
+    fun wakeUp() {
+        requireGeneralCall().write(byteArrayOf(0x09))
+    }
+
+    /**
+     * Send General Call Reset (address 0x00, command 0x06).
+     *
+     * Triggers an internal power-on reset on all MCP47xx devices on the bus
+     * that support General Call, reloading EEPROM contents into the DAC register.
+     *
+     * @throws IllegalStateException if no General Call transport was provided
+     */
+    fun reset() {
+        requireGeneralCall().write(byteArrayOf(0x06))
+    }
+
+    /**
+     * Read the RDY/BSY bit.
+     *
+     * @return true when the EEPROM write is complete
+     */
+    fun isEepromReady(): Boolean =
+        (transport.read(1)[0].toInt() and 0x80) != 0
+
+    private fun requireGeneralCall(): Transport =
+        generalCall ?: throw IllegalStateException("General Call transport not configured")
+}

--- a/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/adc_dac/Mcp4725Minimal.kt
+++ b/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/adc_dac/Mcp4725Minimal.kt
@@ -1,0 +1,48 @@
+package it.uhde.periph.chips.adc_dac
+
+import it.uhde.periph.transport.Transport
+import kotlin.math.roundToInt
+
+/**
+ * MCP4725 — 12-bit single-channel DAC with I²C interface (minimal driver).
+ *
+ * Outputs a voltage from 0 V to V_DD by writing a 12-bit code over I²C.
+ * Only the DAC register is updated; the EEPROM is never touched by this class.
+ * All writes use the Fast Write command (2 bytes).
+ *
+ * Default I²C address: 0x60 (A0 pin = GND), 0x61 (A0 pin = VDD).
+ */
+open class Mcp4725Minimal(protected val transport: Transport) {
+
+    /** Last code written; used by subclass [Mcp4725Full.setPowerDown] to preserve the output level. */
+    protected var lastCode: Int = 0
+
+    /**
+     * Set the DAC output as a fraction of V_DD using a Fast Write.
+     *
+     * Fraction is clamped to [0.0, 1.0]. Maps to a 12-bit code via
+     * `code = round(fraction × 4095)`.
+     *
+     * @param fraction target output level, 0.0 = 0 V, 1.0 = V_DD
+     */
+    fun setVoltage(fraction: Double) {
+        setRaw((fraction.coerceIn(0.0, 1.0) * 4095).roundToInt())
+    }
+
+    /**
+     * Set the DAC output to a raw 12-bit code using a Fast Write.
+     *
+     * Code is clamped to [0, 4095]. Output voltage = V_DD × code / 4096.
+     *
+     * @param code 12-bit DAC value (0–4095)
+     */
+    fun setRaw(code: Int) {
+        val c = code.coerceIn(0, 4095)
+        lastCode = c
+        // Fast Write: [0 0 PD1 PD0 D11-D8] [D7-D0]  — PD1=PD0=0 (normal mode)
+        transport.write(byteArrayOf(
+            ((c shr 8) and 0x0F).toByte(),
+            (c and 0xFF).toByte()
+        ))
+    }
+}

--- a/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina219Full.kt
+++ b/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina219Full.kt
@@ -1,0 +1,181 @@
+package it.uhde.periph.chips.power
+
+import it.uhde.periph.transport.Transport
+
+/**
+ * INA219 — full driver. Extends [Ina219Minimal] with ADC configuration,
+ * conversion-ready and overflow status, software reset, power-down, wake, and
+ * one-shot trigger.
+ *
+ * ## Configuration register layout (0x00)
+ * ```
+ * Bit 15    : RST  — software reset (self-clearing)
+ * Bit 13    : BRNG — bus voltage range (0 = 16 V, 1 = 32 V)
+ * Bits 12:11: PG   — PGA gain (00 = /1, 01 = /2, 10 = /4, 11 = /8)
+ * Bits 10:7 : BADC — bus ADC resolution / averaging
+ * Bits  6:3 : SADC — shunt ADC resolution / averaging
+ * Bits  2:0 : MODE — operating mode
+ * ```
+ *
+ * @param transport  I²C transport bound to the INA219 device address
+ * @param rShunt     shunt resistance in Ω (default 0.1)
+ * @param maxCurrent maximum expected current in A (default 2.0)
+ */
+class Ina219Full @JvmOverloads constructor(
+    transport: Transport,
+    rShunt: Double = 0.1,
+    maxCurrent: Double = 2.0
+) : Ina219Minimal(transport, rShunt, maxCurrent) {
+
+    companion object {
+        // PGA gain
+        /** PGA /1: ±40 mV full-scale shunt range. */
+        const val PGA_1 = 0
+        /** PGA /2: ±80 mV full-scale shunt range. */
+        const val PGA_2 = 1
+        /** PGA /4: ±160 mV full-scale shunt range. */
+        const val PGA_4 = 2
+        /** PGA /8: ±320 mV full-scale shunt range (hardware default). */
+        const val PGA_8 = 3
+
+        // Bus voltage range
+        /** Bus voltage range: 16 V full-scale. */
+        const val BRNG_16V = 0
+        /** Bus voltage range: 32 V full-scale (hardware default). */
+        const val BRNG_32V = 1
+
+        // ADC resolution / averaging
+        /** ADC: 9-bit single sample (84 µs). */
+        const val ADC_9BIT    = 0
+        /** ADC: 10-bit single sample (148 µs). */
+        const val ADC_10BIT   = 1
+        /** ADC: 11-bit single sample (276 µs). */
+        const val ADC_11BIT   = 2
+        /** ADC: 12-bit single sample (532 µs, hardware default). */
+        const val ADC_12BIT   = 3
+        /** ADC: 2-sample average (1.06 ms). */
+        const val ADC_AVG_2   = 9
+        /** ADC: 4-sample average (2.13 ms). */
+        const val ADC_AVG_4   = 10
+        /** ADC: 8-sample average (4.26 ms). */
+        const val ADC_AVG_8   = 11
+        /** ADC: 16-sample average (8.51 ms). */
+        const val ADC_AVG_16  = 12
+        /** ADC: 32-sample average (17.02 ms). */
+        const val ADC_AVG_32  = 13
+        /** ADC: 64-sample average (34.05 ms). */
+        const val ADC_AVG_64  = 14
+        /** ADC: 128-sample average (68.10 ms). */
+        const val ADC_AVG_128 = 15
+
+        // Operating modes
+        /** Mode: power-down (low quiescent current, ADC powered off). */
+        const val MODE_POWERDOWN      = 0
+        /** Mode: shunt voltage, triggered (single shot). */
+        const val MODE_SHUNT_TRIG     = 1
+        /** Mode: bus voltage, triggered (single shot). */
+        const val MODE_BUS_TRIG       = 2
+        /** Mode: shunt and bus voltage, triggered (single shot). */
+        const val MODE_SHUNT_BUS_TRIG = 3
+        /** Mode: ADC off (power-down while configuration bits are held). */
+        const val MODE_ADC_OFF        = 4
+        /** Mode: shunt voltage, continuous. */
+        const val MODE_SHUNT_CONT     = 5
+        /** Mode: bus voltage, continuous. */
+        const val MODE_BUS_CONT       = 6
+        /** Mode: shunt and bus voltage, continuous (hardware default). */
+        const val MODE_SHUNT_BUS_CONT = 7
+    }
+
+    /** Cached configuration register value. */
+    private var config: Int = 0x399F
+
+    /**
+     * Write the configuration register.
+     *
+     * All five fields are packed into the 16-bit register and written
+     * atomically. The value is cached so [reset], [shutdown], and [wake]
+     * can restore or modify it without a read-modify-write bus cycle.
+     *
+     * @param brng bus voltage range (0 = 16 V, 1 = 32 V)
+     * @param pga  PGA gain (0–3); see [PGA_1]–[PGA_8]
+     * @param badc bus ADC resolution/averaging (0–3 or 9–15)
+     * @param sadc shunt ADC resolution/averaging (0–3 or 9–15)
+     * @param mode operating mode (0–7); see [MODE_POWERDOWN]–[MODE_SHUNT_BUS_CONT]
+     */
+    fun configure(brng: Int, pga: Int, badc: Int, sadc: Int, mode: Int) {
+        config = ((brng and 0x01) shl 13) or
+                 ((pga  and 0x03) shl 11) or
+                 ((badc and 0x0F) shl  7) or
+                 ((sadc and 0x0F) shl  3) or
+                 (mode  and 0x07)
+        writeReg(REG_CONFIG, config)
+    }
+
+    /**
+     * Check whether a new conversion result is available.
+     *
+     * Reads the Bus Voltage register and tests the CNVR bit (bit 1). In
+     * triggered modes the bit is set when a complete measurement is ready.
+     *
+     * @return `true` when a conversion is ready to be read
+     */
+    fun conversionReady(): Boolean = (readReg(REG_BUS_V) and 0x02) != 0
+
+    /**
+     * Check the math overflow flag.
+     *
+     * Reads the Bus Voltage register and tests the OVF bit (bit 0). The flag
+     * is set when the power or current calculation has exceeded register
+     * capacity; current and power readings will be invalid until it clears.
+     *
+     * @return `true` when an arithmetic overflow has occurred
+     */
+    fun overflow(): Boolean = (readReg(REG_BUS_V) and 0x01) != 0
+
+    /**
+     * Perform a software reset and restore the configuration and calibration.
+     *
+     * Sets the RST bit (bit 15), triggering an internal power-on reset.
+     * Then re-writes the cached configuration and recomputes and re-writes the
+     * calibration register to restore the driver to its pre-reset state.
+     */
+    fun reset() {
+        writeReg(REG_CONFIG, 0x8000)
+        writeReg(REG_CONFIG, config)
+        val cal = (0.04096 / (currentLsb * rShunt)).toInt() and 0xFFFE
+        writeReg(REG_CALIBRATE, cal)
+    }
+
+    /**
+     * Enter power-down mode (MODE bits = 000).
+     *
+     * Writes the cached configuration with the MODE field replaced by
+     * [MODE_POWERDOWN]. The remaining configuration bits are preserved.
+     * Call [wake] to exit.
+     */
+    fun shutdown() {
+        writeReg(REG_CONFIG, (config and 0x07.inv()) or MODE_POWERDOWN)
+    }
+
+    /**
+     * Exit power-down mode by restoring the cached configuration.
+     *
+     * Re-writes the full cached configuration register, reinstating the
+     * original operating mode. Typically called after [shutdown].
+     */
+    fun wake() {
+        writeReg(REG_CONFIG, config)
+    }
+
+    /**
+     * Trigger a one-shot conversion by re-writing the configuration register.
+     *
+     * In triggered modes ([MODE_SHUNT_TRIG], [MODE_BUS_TRIG],
+     * [MODE_SHUNT_BUS_TRIG]) re-writing the configuration register initiates a
+     * new single conversion. Calling this in continuous mode is harmless.
+     */
+    fun trigger() {
+        writeReg(REG_CONFIG, config)
+    }
+}

--- a/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina219Minimal.kt
+++ b/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina219Minimal.kt
@@ -1,0 +1,126 @@
+package it.uhde.periph.chips.power
+
+import it.uhde.periph.transport.Transport
+
+/**
+ * INA219 — zero-drift, bidirectional current/power monitor with I²C interface
+ * (minimal driver).
+ *
+ * Measures bus voltage (0–32 V), shunt voltage, current, and power via a
+ * sense resistor on the high or low side of the load. The calibration register
+ * is computed and written once during construction; the configuration register
+ * is left at its hardware reset value (0x399F: ±32 V bus, PGA /8, 12-bit,
+ * continuous shunt+bus mode).
+ *
+ * Default I²C address: 0x40 (A1=GND, A0=GND).
+ *
+ * @param transport  I²C transport bound to the INA219 device address
+ * @param rShunt     shunt resistance in Ω (default 0.1)
+ * @param maxCurrent maximum expected current in A (default 2.0)
+ */
+open class Ina219Minimal @JvmOverloads constructor(
+    protected val transport: Transport,
+    protected val rShunt: Double = 0.1,
+    maxCurrent: Double = 2.0
+) {
+    /** Current register LSB in A/LSB. */
+    protected val currentLsb: Double = maxCurrent / 32768.0
+
+    /** Power register LSB in W/LSB (= 20 × currentLsb). */
+    protected val powerLsb: Double = 20.0 * currentLsb
+
+    companion object {
+        const val REG_CONFIG    = 0x00
+        const val REG_SHUNT_V   = 0x01
+        const val REG_BUS_V     = 0x02
+        const val REG_POWER     = 0x03
+        const val REG_CURRENT   = 0x04
+        const val REG_CALIBRATE = 0x05
+    }
+
+    init {
+        val cal = (0.04096 / (currentLsb * rShunt)).toInt() and 0xFFFE
+        writeReg(REG_CALIBRATE, cal)
+    }
+
+    /**
+     * Read the bus voltage.
+     *
+     * Reads the Bus Voltage register (0x02), right-shifts by 3, and
+     * multiplies by the 4 mV LSB. Range: 0–32 V.
+     *
+     * @return bus voltage in V
+     */
+    fun voltage(): Double {
+        val raw = readReg(REG_BUS_V)
+        return ((raw shr 3) and 0x1FFF) * 4e-3
+    }
+
+    /**
+     * Read the shunt (differential) voltage.
+     *
+     * Reads the Shunt Voltage register (0x01) as a signed 16-bit value and
+     * multiplies by the 10 µV LSB.
+     *
+     * @return shunt voltage in V (negative for reverse current flow)
+     */
+    fun shuntVoltage(): Double {
+        val raw = readReg(REG_SHUNT_V)
+        return raw.toShort() * 10e-6
+    }
+
+    /**
+     * Read the current through the shunt resistor.
+     *
+     * Reads the Current register (0x04) as a signed 16-bit value and
+     * multiplies by the current LSB computed during construction.
+     *
+     * @return current in A (negative for reverse flow)
+     */
+    fun current(): Double {
+        val raw = readReg(REG_CURRENT)
+        return raw.toShort() * currentLsb
+    }
+
+    /**
+     * Read the calculated power.
+     *
+     * Reads the Power register (0x03) as an unsigned 16-bit value and
+     * multiplies by the power LSB (= 20 × current LSB).
+     *
+     * @return power in W (always non-negative)
+     */
+    fun power(): Double {
+        val raw = readReg(REG_POWER)
+        return (raw and 0xFFFF) * powerLsb
+    }
+
+    // -------------------------------------------------------------------------
+    // Protected register I/O helpers (shared with Ina219Full)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Read a 16-bit big-endian register.
+     *
+     * @param reg register address (0x00–0x05)
+     * @return raw unsigned 16-bit value
+     */
+    protected fun readReg(reg: Int): Int {
+        val b = transport.writeRead(byteArrayOf(reg.toByte()), 2)
+        return ((b[0].toInt() and 0xFF) shl 8) or (b[1].toInt() and 0xFF)
+    }
+
+    /**
+     * Write a 16-bit big-endian register.
+     *
+     * @param reg register address (0x00–0x05)
+     * @param val 16-bit value to write
+     */
+    protected fun writeReg(reg: Int, `val`: Int) {
+        transport.write(byteArrayOf(
+            reg.toByte(),
+            ((`val` shr 8) and 0xFF).toByte(),
+            (`val` and 0xFF).toByte()
+        ))
+    }
+}

--- a/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina226Full.kt
+++ b/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina226Full.kt
@@ -1,0 +1,217 @@
+package it.uhde.periph.chips.power
+
+import it.uhde.periph.transport.Transport
+
+/**
+ * INA226 — full driver. Extends [Ina226Minimal] with configuration,
+ * alert management, conversion-ready polling, reset, shutdown/wake, and
+ * device identification.
+ *
+ * ## Alert functions (bit positions in Mask/Enable register)
+ * - [SOL]  — shunt voltage over-limit (bit 15)
+ * - [SUL]  — shunt voltage under-limit (bit 14)
+ * - [BOL]  — bus voltage over-limit (bit 13)
+ * - [BUL]  — bus voltage under-limit (bit 12)
+ * - [POL]  — power over-limit (bit 11)
+ * - [CNVR] — conversion ready (bit 10)
+ *
+ * ## Averaging constants
+ * [AVG_1], [AVG_4], [AVG_16], [AVG_64], [AVG_128], [AVG_256], [AVG_512], [AVG_1024]
+ *
+ * ## Conversion time constants
+ * [CT_140US], [CT_204US], [CT_332US], [CT_588US],
+ * [CT_1100US], [CT_2116US], [CT_4156US], [CT_8244US]
+ *
+ * ## Mode constants
+ * [MODE_POWERDOWN], [MODE_SHUNT_TRIG], [MODE_BUS_TRIG], [MODE_SHUNT_BUS_TRIG],
+ * [MODE_SHUNT_CONT], [MODE_BUS_CONT], [MODE_SHUNT_BUS_CONT]
+ */
+class Ina226Full @JvmOverloads constructor(
+    transport: Transport,
+    rShunt: Double = 0.1,
+    maxCurrent: Double = 2.0
+) : Ina226Minimal(transport, rShunt, maxCurrent) {
+
+    companion object {
+        // Alert function constants
+        /** Alert: shunt voltage over-limit (bit 15). */
+        const val SOL  = 32768
+        /** Alert: shunt voltage under-limit (bit 14). */
+        const val SUL  = 16384
+        /** Alert: bus voltage over-limit (bit 13). */
+        const val BOL  = 8192
+        /** Alert: bus voltage under-limit (bit 12). */
+        const val BUL  = 4096
+        /** Alert: power over-limit (bit 11). */
+        const val POL  = 2048
+        /** Alert: conversion ready (bit 10). */
+        const val CNVR = 1024
+
+        // Averaging constants
+        /** Averaging: 1 sample. */
+        const val AVG_1    = 0
+        /** Averaging: 4 samples. */
+        const val AVG_4    = 1
+        /** Averaging: 16 samples. */
+        const val AVG_16   = 2
+        /** Averaging: 64 samples. */
+        const val AVG_64   = 3
+        /** Averaging: 128 samples. */
+        const val AVG_128  = 4
+        /** Averaging: 256 samples. */
+        const val AVG_256  = 5
+        /** Averaging: 512 samples. */
+        const val AVG_512  = 6
+        /** Averaging: 1024 samples. */
+        const val AVG_1024 = 7
+
+        // Conversion time constants
+        /** Conversion time: 140 µs. */
+        const val CT_140US  = 0
+        /** Conversion time: 204 µs. */
+        const val CT_204US  = 1
+        /** Conversion time: 332 µs. */
+        const val CT_332US  = 2
+        /** Conversion time: 588 µs. */
+        const val CT_588US  = 3
+        /** Conversion time: 1.1 ms. */
+        const val CT_1100US = 4
+        /** Conversion time: 2.116 ms. */
+        const val CT_2116US = 5
+        /** Conversion time: 4.156 ms. */
+        const val CT_4156US = 6
+        /** Conversion time: 8.244 ms. */
+        const val CT_8244US = 7
+
+        // Mode constants
+        /** Mode: power-down (0). */
+        const val MODE_POWERDOWN      = 0
+        /** Mode: shunt voltage triggered (1). */
+        const val MODE_SHUNT_TRIG     = 1
+        /** Mode: bus voltage triggered (2). */
+        const val MODE_BUS_TRIG       = 2
+        /** Mode: shunt and bus voltage triggered (3). */
+        const val MODE_SHUNT_BUS_TRIG = 3
+        /** Mode: shunt voltage continuous (5). */
+        const val MODE_SHUNT_CONT     = 5
+        /** Mode: bus voltage continuous (6). */
+        const val MODE_BUS_CONT       = 6
+        /** Mode: shunt and bus voltage continuous (7). */
+        const val MODE_SHUNT_BUS_CONT = 7
+    }
+
+    /**
+     * Write the Configuration register.
+     *
+     * Bits are packed as:
+     * `[0 0 0 0 | AVG2 AVG1 AVG0 | VBUSCT2 VBUSCT1 VBUSCT0 | VSHCT2 VSHCT1 VSHCT0 | MODE2 MODE1 MODE0]`
+     *
+     * @param avg    averaging count (0–7, use [AVG_*][AVG_1] constants)
+     * @param vbusCt bus voltage conversion time (0–7, use [CT_*][CT_140US] constants)
+     * @param vshCt  shunt voltage conversion time (0–7, use [CT_*][CT_140US] constants)
+     * @param mode   operating mode (0–7, use [MODE_*][MODE_POWERDOWN] constants)
+     */
+    fun configure(avg: Int, vbusCt: Int, vshCt: Int, mode: Int) {
+        val cfg = ((avg    and 0x07) shl 9) or
+                  ((vbusCt and 0x07) shl 6) or
+                  ((vshCt  and 0x07) shl 3) or
+                   (mode   and 0x07)
+        lastMode = mode and 0x07
+        writeReg(REG_CONFIG, cfg)
+    }
+
+    /**
+     * Check whether a conversion has completed (CVRF flag, bit 3 of Mask/Enable).
+     *
+     * @return true if a conversion is ready to be read
+     */
+    fun conversionReady(): Boolean = (readReg(REG_MASK_EN) and 0x08) != 0
+
+    /**
+     * Check whether a math overflow occurred (OVF flag, bit 2 of Mask/Enable).
+     *
+     * An overflow means the current or power result exceeded the register range;
+     * reduce maxCurrent or increase rShunt to avoid this condition.
+     *
+     * @return true if an overflow has occurred
+     */
+    fun overflow(): Boolean = (readReg(REG_MASK_EN) and 0x04) != 0
+
+    /**
+     * Configure an alert function and its threshold.
+     *
+     * The raw limit is derived from the physical limit:
+     * - SOL/SUL: raw = int(limit_V / 2.5e-6)
+     * - BOL/BUL: raw = int(limit_V / 1.25e-3)
+     * - POL:     raw = int(limit_W / (25 × Current_LSB))
+     * - CNVR:    limit is ignored
+     *
+     * @param function alert function bitmask (e.g. [POL])
+     * @param limit    physical threshold (V for shunt/bus, W for power)
+     */
+    fun setAlert(function: Int, limit: Double) {
+        val raw = when (function) {
+            SOL, SUL -> (limit / 2.5e-6).toInt()
+            BOL, BUL -> (limit / 1.25e-3).toInt()
+            POL      -> (limit / (25.0 * currentLsb)).toInt()
+            else     -> 0
+        }
+        writeReg(REG_MASK_EN, function)
+        writeReg(REG_ALERT_LIM, raw and 0xFFFF)
+    }
+
+    /**
+     * Read the raw Mask/Enable register value.
+     *
+     * Reading this register also clears the alert latch. The flags of interest
+     * are CVRF (bit 3) and OVF (bit 2); alert-function bits are in bits 10–15.
+     *
+     * @return raw 16-bit Mask/Enable register value
+     */
+    fun alertFlags(): Int = readReg(REG_MASK_EN)
+
+    /**
+     * Reset the chip (sets RST bit) and re-write calibration.
+     *
+     * After reset the chip returns to default configuration (0x4127). This method
+     * re-writes the Calibration register so that current and power readings remain valid.
+     */
+    fun reset() {
+        writeReg(REG_CONFIG, 0x8000)
+        writeReg(REG_CAL, cal)
+        lastMode = 7
+    }
+
+    /**
+     * Put the chip into power-down mode (MODE=000).
+     *
+     * The current mode is preserved in [lastMode] so that [wake] can restore it.
+     */
+    fun shutdown() {
+        val cfg = readReg(REG_CONFIG)
+        lastMode = cfg and 0x07
+        writeReg(REG_CONFIG, cfg and 0x07.inv())
+    }
+
+    /**
+     * Restore the operating mode that was active before [shutdown].
+     */
+    fun wake() {
+        val cfg = readReg(REG_CONFIG)
+        writeReg(REG_CONFIG, (cfg and 0x07.inv()) or (lastMode and 0x07))
+    }
+
+    /**
+     * Read the Manufacturer ID register.
+     *
+     * @return manufacturer ID (0x5449 = "TI")
+     */
+    fun manufacturerId(): Int = readReg(REG_MFR_ID)
+
+    /**
+     * Read the Die ID register.
+     *
+     * @return die ID (0x2260 for INA226)
+     */
+    fun dieId(): Int = readReg(REG_DIE_ID)
+}

--- a/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina226Minimal.kt
+++ b/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina226Minimal.kt
@@ -1,0 +1,122 @@
+package it.uhde.periph.chips.power
+
+import it.uhde.periph.transport.Transport
+
+/**
+ * INA226 — 16-bit current/power monitor with I²C interface (minimal driver).
+ *
+ * Measures shunt voltage, bus voltage, current, and power. Calibration is
+ * computed from the shunt resistance and maximum expected current; the result
+ * is written to the Calibration register at construction time.
+ *
+ * Default I²C address: 0x40 (A0=GND, A1=GND).
+ *
+ * ## Configuration defaults
+ * - Mode: continuous shunt+bus (7)
+ * - Bus voltage conversion time: 1.1 ms (4)
+ * - Shunt voltage conversion time: 1.1 ms (4)
+ * - Averaging: 1 sample (0)
+ */
+open class Ina226Minimal @JvmOverloads constructor(
+    protected val transport: Transport,
+    rShunt: Double = 0.1,
+    maxCurrent: Double = 2.0
+) {
+    protected val currentLsb: Double = maxCurrent / 32768.0
+    protected val cal: Int = (0.00512 / (currentLsb * rShunt)).toInt()
+
+    /** Stored MODE bits (2:0) for [Ina226Full.wake]. Updated by configure() and shutdown(). */
+    protected var lastMode: Int = 7
+
+    companion object {
+        // Register addresses
+        const val REG_CONFIG    = 0x00
+        const val REG_SHUNT     = 0x01
+        const val REG_BUS       = 0x02
+        const val REG_POWER     = 0x03
+        const val REG_CURRENT   = 0x04
+        const val REG_CAL       = 0x05
+        const val REG_MASK_EN   = 0x06
+        const val REG_ALERT_LIM = 0x07
+        const val REG_MFR_ID    = 0xFE
+        const val REG_DIE_ID    = 0xFF
+
+        /** Default configuration: mode=7, VBUSCT=4, VSHCT=4, AVG=0 → 0x4127. */
+        const val DEFAULT_CONFIG = 0x4127
+    }
+
+    init {
+        writeReg(REG_CONFIG, DEFAULT_CONFIG)
+        writeReg(REG_CAL, cal)
+    }
+
+    /**
+     * Read the bus voltage.
+     *
+     * @return bus voltage in V (1.25 mV LSB, unsigned 16-bit)
+     */
+    fun voltage(): Double = readReg(REG_BUS) * 1.25e-3
+
+    /**
+     * Read the shunt voltage.
+     *
+     * @return shunt voltage in V (2.5 µV LSB, signed 16-bit)
+     */
+    fun shuntVoltage(): Double = readRegSigned(REG_SHUNT) * 2.5e-6
+
+    /**
+     * Read the current through the shunt resistor.
+     *
+     * Requires a valid Calibration register value (written in the constructor).
+     *
+     * @return current in A (signed, Current_LSB per bit)
+     */
+    fun current(): Double = readRegSigned(REG_CURRENT) * currentLsb
+
+    /**
+     * Read the calculated power.
+     *
+     * Power = 25 × Current_LSB × raw power register (unsigned).
+     *
+     * @return power in W
+     */
+    fun power(): Double = readReg(REG_POWER) * 25.0 * currentLsb
+
+    // ---- low-level helpers ----
+
+    /**
+     * Write a 16-bit value to a register (big-endian, register-pointer protocol).
+     *
+     * @param reg register address
+     * @param val 16-bit value
+     */
+    protected fun writeReg(reg: Int, `val`: Int) {
+        transport.write(byteArrayOf(
+            reg.toByte(),
+            (`val` shr 8).toByte(),
+            (`val` and 0xFF).toByte()
+        ))
+    }
+
+    /**
+     * Read an unsigned 16-bit value from a register.
+     *
+     * @param reg register address
+     * @return unsigned 16-bit value (0–65535)
+     */
+    protected fun readReg(reg: Int): Int {
+        val b = transport.writeRead(byteArrayOf(reg.toByte()), 2)
+        return ((b[0].toInt() and 0xFF) shl 8) or (b[1].toInt() and 0xFF)
+    }
+
+    /**
+     * Read a signed 16-bit value from a register.
+     *
+     * @param reg register address
+     * @return signed 16-bit value (-32768–32767)
+     */
+    protected fun readRegSigned(reg: Int): Int {
+        val b = transport.writeRead(byteArrayOf(reg.toByte()), 2)
+        return (((b[0].toInt() and 0xFF) shl 8) or (b[1].toInt() and 0xFF)).toShort().toInt()
+    }
+}

--- a/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina3221Full.kt
+++ b/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina3221Full.kt
@@ -1,0 +1,312 @@
+package it.uhde.periph.chips.power
+
+import it.uhde.periph.transport.Transport
+import kotlin.math.roundToInt
+
+/**
+ * INA3221 — full driver. Extends [Ina3221Minimal] with configuration,
+ * per-channel enable/disable, alert limits, summation, power-valid thresholds,
+ * shutdown/wake, and identification registers.
+ *
+ * ## Alert flags
+ * Reading the Mask/Enable register (via [alertFlags]) also clears the latched
+ * alert flags. Read it once after a monitoring interval to capture and clear
+ * all pending alerts.
+ *
+ * ## Mode constants
+ * - [MODE_POWERDOWN] — power-down (0)
+ * - [MODE_SHUNT_TRIG] — shunt triggered (1)
+ * - [MODE_BUS_TRIG] — bus triggered (2)
+ * - [MODE_SHUNT_BUS_TRIG] — shunt + bus triggered (3)
+ * - [MODE_SHUNT_CONT] — shunt continuous (5)
+ * - [MODE_BUS_CONT] — bus continuous (6)
+ * - [MODE_SHUNT_BUS_CONT] — shunt + bus continuous (7, default)
+ */
+class Ina3221Full : Ina3221Minimal {
+
+    companion object {
+        // Register addresses
+        private const val REG_CONFIG       = 0x00
+        private const val REG_MASK_ENABLE  = 0x0F
+        private const val REG_CH1_CRIT     = 0x07
+        private const val REG_CH1_WARN     = 0x08
+        private const val REG_SV_SUM       = 0x0D
+        private const val REG_SV_SUM_LIMIT = 0x0E
+        private const val REG_PV_UPPER     = 0x10
+        private const val REG_PV_LOWER     = 0x11
+        private const val REG_MANUFACTURER = 0xFE
+        private const val REG_DIE_ID       = 0xFF
+
+        // Mode constants
+        /** Power-down mode (MODE bits = 000). */
+        const val MODE_POWERDOWN      = 0
+        /** Single-shot shunt voltage measurement (MODE bits = 001). */
+        const val MODE_SHUNT_TRIG     = 1
+        /** Single-shot bus voltage measurement (MODE bits = 010). */
+        const val MODE_BUS_TRIG       = 2
+        /** Single-shot shunt and bus voltage measurement (MODE bits = 011). */
+        const val MODE_SHUNT_BUS_TRIG = 3
+        /** Continuous shunt voltage measurement (MODE bits = 101). */
+        const val MODE_SHUNT_CONT     = 5
+        /** Continuous bus voltage measurement (MODE bits = 110). */
+        const val MODE_BUS_CONT       = 6
+        /** Continuous shunt and bus voltage measurement (MODE bits = 111, default). */
+        const val MODE_SHUNT_BUS_CONT = 7
+
+        // Mask/Enable bit positions
+        /** Critical flag channel 1 (bit 9). */
+        const val CF1  = 512
+        /** Critical flag channel 2 (bit 8). */
+        const val CF2  = 256
+        /** Critical flag channel 3 (bit 7). */
+        const val CF3  = 128
+        /** Summation flag (bit 6). */
+        const val SF   = 64
+        /** Warning flag channel 1 (bit 5). */
+        const val WF1  = 32
+        /** Warning flag channel 2 (bit 4). */
+        const val WF2  = 16
+        /** Warning flag channel 3 (bit 3). */
+        const val WF3  = 8
+        /** Power-valid flag (bit 2). */
+        const val PVF  = 4
+        /** Timing control flag (bit 1). */
+        const val TCF  = 2
+        /** Conversion-ready flag (bit 0). */
+        const val CVRF = 1
+    }
+
+    /** Last user-configured MODE bits; saved so [wake] can restore them. */
+    private var savedMode = MODE_SHUNT_BUS_CONT
+
+    /**
+     * Construct with a uniform shunt resistance for all channels.
+     *
+     * @param transport I²C transport bound to the INA3221 device address
+     * @param rShunt    shunt resistance in Ω applied to all three channels
+     */
+    constructor(transport: Transport, rShunt: Double) : super(transport, rShunt)
+
+    /**
+     * Construct with per-channel shunt resistances.
+     *
+     * @param transport I²C transport bound to the INA3221 device address
+     * @param rShunts   shunt resistances in Ω for channels 1, 2, and 3
+     */
+    constructor(transport: Transport, rShunts: DoubleArray) : super(transport, rShunts)
+
+    /**
+     * Construct with the default shunt resistance (0.1 Ω) for all channels.
+     *
+     * @param transport I²C transport bound to the INA3221 device address
+     */
+    constructor(transport: Transport) : super(transport)
+
+    /**
+     * Write the configuration register, preserving the channel-enable bits.
+     *
+     * The channel-enable bits (CH1en, CH2en, CH3en) in the current configuration
+     * are read first and retained so that calling configure() does not inadvertently
+     * disable channels.
+     *
+     * @param avg    averaging mode (0–7): 0=1, 1=4, 2=16, 3=64, 4=128, 5=256, 6=512, 7=1024 samples
+     * @param vbusCt bus voltage conversion time (0–7)
+     * @param vshCt  shunt voltage conversion time (0–7)
+     * @param mode   operating mode (0–7); use MODE_* constants
+     */
+    fun configure(avg: Int, vbusCt: Int, vshCt: Int, mode: Int) {
+        savedMode = mode and 0x07
+        val current = readReg(REG_CONFIG)
+        val channelBits = current and 0x7000
+        val value = channelBits or
+                ((avg    and 0x07) shl 9) or
+                ((vbusCt and 0x07) shl 6) or
+                ((vshCt  and 0x07) shl 3) or
+                (mode    and 0x07)
+        writeReg(REG_CONFIG, value)
+    }
+
+    /**
+     * Enable or disable a channel.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @param enabled true to enable, false to disable
+     */
+    fun enableChannel(channel: Int, enabled: Boolean) {
+        checkChannel(channel)
+        val bit = 1 shl (15 - channel)
+        var cfg = readReg(REG_CONFIG)
+        cfg = if (enabled) cfg or bit else cfg and bit.inv()
+        writeReg(REG_CONFIG, cfg and 0xFFFF)
+    }
+
+    /**
+     * Read whether a channel is currently enabled.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @return true if the channel enable bit is set
+     */
+    fun channelEnabled(channel: Int): Boolean {
+        checkChannel(channel)
+        val bit = 1 shl (15 - channel)
+        return (readReg(REG_CONFIG) and bit) != 0
+    }
+
+    /**
+     * Read the Conversion Ready Flag (CVRF) from the Mask/Enable register.
+     *
+     * CVRF is set after a complete conversion cycle.
+     *
+     * @return true if a conversion cycle has completed since the last read
+     */
+    fun conversionReady(): Boolean = (readReg(REG_MASK_ENABLE) and CVRF) != 0
+
+    /**
+     * Set the critical alert limit for a channel.
+     *
+     * The alert fires when the shunt voltage magnitude exceeds this limit.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @param limitV  shunt voltage threshold in V (positive)
+     */
+    fun setCriticalAlert(channel: Int, limitV: Double) {
+        checkChannel(channel)
+        val reg = REG_CH1_CRIT + (channel - 1) * 2
+        writeReg(reg, encodeAlertLimit(limitV))
+    }
+
+    /**
+     * Set the warning alert limit for a channel.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @param limitV  shunt voltage threshold in V (positive)
+     */
+    fun setWarningAlert(channel: Int, limitV: Double) {
+        checkChannel(channel)
+        val reg = REG_CH1_WARN + (channel - 1) * 2
+        writeReg(reg, encodeAlertLimit(limitV))
+    }
+
+    /**
+     * Read and clear the Mask/Enable register (alert flags).
+     *
+     * Reading this register clears all latched alert flag bits. The returned value
+     * can be inspected against the CF1, CF2, CF3, SF, WF1, WF2, WF3, PVF, TCF,
+     * and CVRF constants.
+     *
+     * @return the raw 16-bit Mask/Enable register value
+     */
+    fun alertFlags(): Int = readReg(REG_MASK_ENABLE)
+
+    /**
+     * Set the summation channel selection (SCC) bits and the summation limit.
+     *
+     * The SCC bits in the Mask/Enable register determine which channels contribute
+     * to the shunt-voltage sum.
+     *
+     * @param channels array of channel numbers to include in the sum (values 1–3)
+     * @param limitV   summation shunt voltage limit in V
+     */
+    fun setSummationChannels(channels: IntArray, limitV: Double) {
+        var me = readReg(REG_MASK_ENABLE) and 0x0FFF
+        for (ch in channels) {
+            checkChannel(ch)
+            me = me or (1 shl (15 - ch))
+        }
+        writeReg(REG_MASK_ENABLE, me and 0xFFFF)
+        val raw = (limitV / 40e-6).roundToInt() and 0x7FFE
+        writeReg(REG_SV_SUM_LIMIT, (raw shl 1) and 0xFFFE)
+    }
+
+    /**
+     * Read the shunt-voltage sum register.
+     *
+     * The register holds a 14-bit signed value, left-aligned by 1 bit (LSB = 20 µV).
+     *
+     * @return shunt-voltage sum in V
+     */
+    fun summationValue(): Double {
+        val raw = readReg(REG_SV_SUM)
+        return (raw.toShort().toInt() shr 1) * 40e-6
+    }
+
+    /**
+     * Set the power-valid upper and lower voltage thresholds.
+     *
+     * The power-valid flag (PVF) is set when all enabled bus voltages are between
+     * lowerV and upperV. Thresholds are 12-bit unsigned, left-aligned by 3 bits
+     * (8 mV LSB).
+     *
+     * @param upperV upper threshold in V (register 0x10, reset = 10.000 V)
+     * @param lowerV lower threshold in V (register 0x11, reset = 9.000 V)
+     */
+    fun setPowerValidLimits(upperV: Double, lowerV: Double) {
+        writeReg(REG_PV_UPPER, ((upperV / 8e-3).roundToInt() and 0x1FFF) shl 3)
+        writeReg(REG_PV_LOWER, ((lowerV / 8e-3).roundToInt() and 0x1FFF) shl 3)
+    }
+
+    /**
+     * Read the Power Valid Flag (PVF) from the Mask/Enable register.
+     *
+     * @return true if all enabled channels are within the power-valid window
+     */
+    fun powerValid(): Boolean = (readReg(REG_MASK_ENABLE) and PVF) != 0
+
+    /**
+     * Put the device into power-down mode (MODE = 000).
+     *
+     * The current MODE setting is saved so that [wake] can restore it.
+     */
+    fun shutdown() {
+        val cfg = readReg(REG_CONFIG)
+        savedMode = cfg and 0x07
+        writeReg(REG_CONFIG, (cfg and 0xFFF8) or MODE_POWERDOWN)
+    }
+
+    /**
+     * Restore the operating mode saved by the last call to [shutdown] or [configure].
+     *
+     * If neither method has been called, the default continuous shunt+bus mode (7) is restored.
+     */
+    fun wake() {
+        val cfg = readReg(REG_CONFIG)
+        writeReg(REG_CONFIG, (cfg and 0xFFF8) or (savedMode and 0x07))
+    }
+
+    /**
+     * Trigger a software reset by setting the RST bit, then restore the saved mode.
+     *
+     * After reset the chip returns to its hardware defaults. The previously saved mode
+     * is written back so the chip resumes normal operation.
+     */
+    fun reset() {
+        writeReg(REG_CONFIG, 0x8000)
+        val defaults = 0x7127
+        writeReg(REG_CONFIG, (defaults and 0xFFF8) or (savedMode and 0x07))
+    }
+
+    /**
+     * Read the Manufacturer ID register.
+     *
+     * Expected value: 0x5449 ("TI").
+     *
+     * @return manufacturer ID
+     */
+    fun manufacturerId(): Int = readReg(REG_MANUFACTURER)
+
+    /**
+     * Read the Die ID register.
+     *
+     * Expected value: 0x3220.
+     *
+     * @return die ID
+     */
+    fun dieId(): Int = readReg(REG_DIE_ID)
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private fun encodeAlertLimit(limitV: Double): Int =
+        ((limitV / 40e-6).roundToInt() shl 3) and 0xFFF8
+}

--- a/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina3221Minimal.kt
+++ b/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina3221Minimal.kt
@@ -1,0 +1,135 @@
+package it.uhde.periph.chips.power
+
+import it.uhde.periph.transport.Transport
+
+/**
+ * INA3221 — 3-channel, high-side measurement, shunt and bus voltage monitor
+ * with I²C interface (minimal driver).
+ *
+ * Measures bus voltage and shunt voltage on up to three independent channels.
+ * Current and power are computed in software from the shunt voltage and the
+ * per-channel shunt resistance supplied at construction time. There is no
+ * calibration register; all scaling is done in the driver.
+ *
+ * The constructor does not write any registers — the chip's hardware reset
+ * default (configuration register 0x7127: all channels enabled, 1-sample
+ * averaging, 1.1 ms conversion, continuous shunt+bus mode) is suitable for
+ * immediate use.
+ *
+ * Default I²C address: 0x40 (A0=GND, A1=GND).
+ */
+open class Ina3221Minimal(
+    protected val transport: Transport,
+    rShunts: DoubleArray = doubleArrayOf(0.1, 0.1, 0.1)
+) {
+    /** Per-channel shunt resistances in Ω (index 0 = channel 1). */
+    protected val rShunts: DoubleArray
+
+    init {
+        require(rShunts.size == 3) { "rShunts must have exactly 3 elements" }
+        this.rShunts = rShunts.copyOf()
+    }
+
+    /**
+     * Construct with a single shunt resistance applied to all three channels.
+     *
+     * @param transport I²C transport bound to the INA3221 device address
+     * @param rShunt    shunt resistance in Ω for all channels (e.g. 0.1)
+     */
+    constructor(transport: Transport, rShunt: Double) :
+        this(transport, doubleArrayOf(rShunt, rShunt, rShunt))
+
+    companion object {
+        internal val SHUNT_BASE = intArrayOf(0, 0x01, 0x03, 0x05)
+        internal val BUS_BASE   = intArrayOf(0, 0x02, 0x04, 0x06)
+
+        internal fun checkChannel(channel: Int) {
+            require(channel in 1..3) { "channel must be 1..3, got: $channel" }
+        }
+    }
+
+    /**
+     * Read the bus voltage for a channel.
+     *
+     * Reads the left-aligned 12-bit unsigned bus voltage register, right-shifts
+     * by 3, and multiplies by the 8 mV LSB.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @return bus voltage in V
+     */
+    fun voltage(channel: Int): Double {
+        checkChannel(channel)
+        val raw = readReg(BUS_BASE[channel])
+        return (raw shr 3) * 8e-3
+    }
+
+    /**
+     * Read the shunt voltage for a channel.
+     *
+     * Reads the left-aligned 13-bit signed shunt voltage register, right-shifts
+     * by 3 (arithmetic), and multiplies by the 40 µV LSB.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @return shunt voltage in V (may be negative)
+     */
+    fun shuntVoltage(channel: Int): Double {
+        checkChannel(channel)
+        val raw = readReg(SHUNT_BASE[channel])
+        return (raw.toShort().toInt() shr 3) * 40e-6
+    }
+
+    /**
+     * Compute the current through the shunt resistor for a channel.
+     *
+     * Current = shuntVoltage / rShunt[channel].
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @return current in A (may be negative for reverse flow)
+     */
+    fun current(channel: Int): Double {
+        checkChannel(channel)
+        return shuntVoltage(channel) / rShunts[channel - 1]
+    }
+
+    /**
+     * Compute the power consumed on a channel.
+     *
+     * Power = busVoltage × current.
+     *
+     * @param channel channel number (1, 2, or 3)
+     * @return power in W
+     */
+    fun power(channel: Int): Double {
+        checkChannel(channel)
+        return voltage(channel) * current(channel)
+    }
+
+    // -------------------------------------------------------------------------
+    // Protected helpers (shared with Ina3221Full)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Read a 16-bit big-endian register.
+     *
+     * @param reg register address
+     * @return raw unsigned 16-bit value
+     */
+    protected fun readReg(reg: Int): Int {
+        val b = transport.writeRead(byteArrayOf(reg.toByte()), 2)
+        return ((b[0].toInt() and 0xFF) shl 8) or (b[1].toInt() and 0xFF)
+    }
+
+    /**
+     * Write a 16-bit big-endian register.
+     *
+     * @param reg register address
+     * @param val 16-bit value to write
+     */
+    protected fun writeReg(reg: Int, `val`: Int) {
+        transport.write(byteArrayOf(
+            reg.toByte(),
+            ((`val` shr 8) and 0xFF).toByte(),
+            (`val` and 0xFF).toByte()
+        ))
+    }
+}

--- a/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/pressure/Bmp180Full.kt
+++ b/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/pressure/Bmp180Full.kt
@@ -1,0 +1,112 @@
+package it.uhde.periph.chips.pressure
+
+import it.uhde.periph.transport.Transport
+import java.io.IOException
+
+/**
+ * BMP180 — full driver. Extends [Bmp180Minimal] with oversampling control,
+ * altitude calculation, sea-level pressure derivation, chip ID read-back, and
+ * soft reset.
+ *
+ * ## OSS constants
+ * [OSS_ULP], [OSS_STANDARD], [OSS_HIGH_RES], [OSS_ULTRA_HIGH_RES]
+ *
+ * ## Altitude formula
+ * `altitude_m = 44330.0 × (1.0 − (pressure_hPa / seaLevelHpa)^(1/5.255))`
+ */
+class Bmp180Full(transport: Transport) : Bmp180Minimal(transport) {
+
+    companion object {
+        /** Ultra-low-power mode: OSS = 0 (1 sample, ~4.5 ms, 3 µA RMS). */
+        const val OSS_ULP             = 0
+        /** Standard mode: OSS = 1 (2 samples, ~7.5 ms, 5 µA RMS). */
+        const val OSS_STANDARD        = 1
+        /** High-resolution mode: OSS = 2 (4 samples, ~13.5 ms, 7 µA RMS). */
+        const val OSS_HIGH_RES        = 2
+        /** Ultra-high-resolution mode: OSS = 3 (8 samples, ~25.5 ms, 12 µA RMS). */
+        const val OSS_ULTRA_HIGH_RES  = 3
+
+        private const val DEFAULT_SEA_LEVEL_HPA = 1013.25
+    }
+
+    /**
+     * Read the current oversampling setting.
+     *
+     * @return OSS value (0–3)
+     */
+    fun oversampling(): Int = oss
+
+    /**
+     * Set the oversampling setting.
+     *
+     * @param oss oversampling value (0–3); use the OSS_* constants
+     * @throws IllegalArgumentException if oss is outside [0, 3]
+     */
+    fun setOversampling(oss: Int) {
+        require(oss in 0..3) { "OSS must be 0–3, got: $oss" }
+        this.oss = oss
+    }
+
+    /**
+     * Compute altitude using the default sea-level pressure (1013.25 hPa).
+     *
+     * @return altitude in m
+     * @throws IOException on I²C error
+     */
+    fun altitude(): Double = altitude(DEFAULT_SEA_LEVEL_HPA)
+
+    /**
+     * Compute altitude for a given sea-level reference pressure.
+     *
+     * Uses the barometric formula:
+     * `altitude_m = 44330 × (1 − (pressure / seaLevelHpa)^(1/5.255))`
+     *
+     * @param seaLevelHpa reference sea-level pressure in hPa
+     * @return altitude in m
+     * @throws IOException on I²C error
+     */
+    fun altitude(seaLevelHpa: Double): Double {
+        val p = pressure()
+        return 44330.0 * (1.0 - Math.pow(p / seaLevelHpa, 1.0 / 5.255))
+    }
+
+    /**
+     * Back-calculate the sea-level pressure from the current reading and a
+     * known altitude.
+     *
+     * @param altitudeM known altitude in m
+     * @return sea-level pressure in hPa
+     * @throws IOException on I²C error
+     */
+    fun seaLevelPressure(altitudeM: Double): Double {
+        val p = pressure()
+        return p / Math.pow(1.0 - altitudeM / 44330.0, 5.255)
+    }
+
+    /**
+     * Read the chip ID register (0xD0).
+     *
+     * Expected value is 0x55 for BMP180.
+     *
+     * @return chip ID byte
+     * @throws IOException on I²C error
+     */
+    fun chipId(): Int {
+        val b = transport.writeRead(byteArrayOf(REG_ID.toByte()), 1)
+        return b[0].toInt() and 0xFF
+    }
+
+    /**
+     * Perform a soft reset and reload calibration.
+     *
+     * Writes 0xB6 to register 0xE0, waits 15 ms for the chip to complete its
+     * power-on sequence, then re-reads and validates the calibration EEPROM.
+     *
+     * @throws IOException on I²C error or invalid calibration after reset
+     */
+    fun reset() {
+        transport.write(byteArrayOf(REG_SOFT_RST.toByte(), 0xB6.toByte()))
+        Thread.sleep(15)
+        readCalibration()
+    }
+}

--- a/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/pressure/Bmp180Minimal.kt
+++ b/jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/pressure/Bmp180Minimal.kt
@@ -1,0 +1,198 @@
+package it.uhde.periph.chips.pressure
+
+import it.uhde.periph.transport.Transport
+import java.io.IOException
+
+/**
+ * BMP180 — digital barometric pressure and temperature sensor (minimal driver).
+ *
+ * Reads temperature and pressure via I²C using Bosch's integer compensation
+ * algorithm. Calibration coefficients are loaded from the chip's EEPROM during
+ * construction and sanity-checked. The chip ID register is verified to be 0x55.
+ *
+ * Fixed I²C address: 0x77 (hardware-defined, not configurable).
+ *
+ * Default oversampling setting (OSS): 0 (ultra-low-power).
+ */
+open class Bmp180Minimal(protected val transport: Transport) {
+
+    companion object {
+        const val REG_CAL_START = 0xAA
+        const val REG_ID        = 0xD0
+        const val REG_SOFT_RST  = 0xE0
+        const val REG_CTRL_MEAS = 0xF4
+        const val REG_OUT_MSB   = 0xF6
+        const val CMD_TEMP      = 0x2E
+        const val CMD_PRES_OSS  = 0x34
+        const val CHIP_ID       = 0x55
+    }
+
+    // Calibration coefficients
+    protected var AC1: Int = 0
+    protected var AC2: Int = 0
+    protected var AC3: Int = 0
+    protected var AC4: Int = 0   // uint16 — treat as unsigned when used
+    protected var AC5: Int = 0   // uint16
+    protected var AC6: Int = 0   // uint16
+    protected var B1:  Int = 0
+    protected var B2:  Int = 0
+    protected var MB:  Int = 0
+    protected var MC:  Int = 0
+    protected var MD:  Int = 0
+
+    /** Current oversampling setting (0–3). */
+    protected var oss: Int = 0
+
+    init {
+        // Verify chip ID
+        val id = transport.writeRead(byteArrayOf(REG_ID.toByte()), 1)
+        if (id[0].toInt() and 0xFF != CHIP_ID) {
+            throw IOException(
+                "BMP180 not found: expected chip ID 0x55, got 0x${(id[0].toInt() and 0xFF).toString(16)}"
+            )
+        }
+        readCalibration()
+    }
+
+    /**
+     * Read and unpack the 22-byte calibration block from EEPROM (0xAA–0xBF).
+     *
+     * @throws IOException on I²C error or invalid calibration data
+     */
+    protected fun readCalibration() {
+        val cal = transport.writeRead(byteArrayOf(REG_CAL_START.toByte()), 22)
+
+        fun s16(hi: Int, lo: Int): Int = (((cal[hi].toInt() and 0xFF) shl 8) or (cal[lo].toInt() and 0xFF)).toShort().toInt()
+        fun u16(hi: Int, lo: Int): Int =  ((cal[hi].toInt() and 0xFF) shl 8) or (cal[lo].toInt() and 0xFF)
+
+        AC1 = s16( 0,  1)
+        AC2 = s16( 2,  3)
+        AC3 = s16( 4,  5)
+        AC4 = u16( 6,  7)
+        AC5 = u16( 8,  9)
+        AC6 = u16(10, 11)
+        B1  = s16(12, 13)
+        B2  = s16(14, 15)
+        MB  = s16(16, 17)
+        MC  = s16(18, 19)
+        MD  = s16(20, 21)
+
+        checkCalibration()
+    }
+
+    /**
+     * Sanity-check: no coefficient may be 0x0000 or 0xFFFF.
+     *
+     * @throws IOException if any coefficient is 0x0000 or 0xFFFF
+     */
+    protected fun checkCalibration() {
+        val raw16 = intArrayOf(
+            AC1 and 0xFFFF, AC2 and 0xFFFF, AC3 and 0xFFFF,
+            AC4 and 0xFFFF, AC5 and 0xFFFF, AC6 and 0xFFFF,
+            B1  and 0xFFFF, B2  and 0xFFFF,
+            MB  and 0xFFFF, MC  and 0xFFFF, MD  and 0xFFFF
+        )
+        val names = arrayOf("AC1","AC2","AC3","AC4","AC5","AC6","B1","B2","MB","MC","MD")
+        for (i in raw16.indices) {
+            if (raw16[i] == 0x0000 || raw16[i] == 0xFFFF) {
+                throw IOException(
+                    "BMP180 calibration invalid: ${names[i]} = 0x${raw16[i].toString(16)}"
+                )
+            }
+        }
+    }
+
+    /**
+     * Trigger a temperature measurement and return the raw ADC value (UT).
+     *
+     * @return unsigned 16-bit raw temperature
+     */
+    protected fun readRawTemperature(): Int {
+        transport.write(byteArrayOf(REG_CTRL_MEAS.toByte(), CMD_TEMP.toByte()))
+        Thread.sleep(5)
+        val b = transport.writeRead(byteArrayOf(REG_OUT_MSB.toByte()), 2)
+        return ((b[0].toInt() and 0xFF) shl 8) or (b[1].toInt() and 0xFF)
+    }
+
+    /**
+     * Trigger a pressure measurement and return the raw ADC value (UP).
+     *
+     * @param ossMode oversampling setting (0–3)
+     * @return raw pressure ADC value (shifted by oss)
+     */
+    protected fun readRawPressure(ossMode: Int): Long {
+        transport.write(byteArrayOf(REG_CTRL_MEAS.toByte(), (CMD_PRES_OSS or (ossMode shl 6)).toByte()))
+        Thread.sleep(ossMode * 10L + 5L)
+        val b = transport.writeRead(byteArrayOf(REG_OUT_MSB.toByte()), 3)
+        val raw = ((b[0].toLong() and 0xFF) shl 16) or ((b[1].toLong() and 0xFF) shl 8) or (b[2].toLong() and 0xFF)
+        return raw shr (8 - ossMode)
+    }
+
+    /**
+     * Compute B5 from a raw temperature value (UT).
+     *
+     * @param UT raw temperature ADC value
+     * @return B5 (shared intermediate used by both temperature and pressure compensation)
+     */
+    protected fun computeB5(UT: Int): Long {
+        val X1 = ((UT.toLong() - AC6.toLong()) * AC5.toLong()) shr 15
+        val X2 = (MC.toLong() shl 11) / (X1 + MD.toLong())
+        return X1 + X2
+    }
+
+    /**
+     * Read the temperature.
+     *
+     * Triggers a temperature measurement, runs Bosch integer compensation,
+     * and returns the result in degrees Celsius.
+     *
+     * @return temperature in °C
+     * @throws IOException on I²C error
+     */
+    fun temperature(): Double {
+        val UT = readRawTemperature()
+        val B5 = computeB5(UT)
+        val T  = (B5 + 8) shr 4
+        return T / 10.0
+    }
+
+    /**
+     * Read the pressure.
+     *
+     * Re-reads temperature internally to refresh B5, then triggers a pressure
+     * measurement. Runs Bosch integer compensation and returns the result in hPa.
+     *
+     * @return pressure in hPa
+     * @throws IOException on I²C error
+     */
+    fun pressure(): Double {
+        val UT = readRawTemperature()
+        val B5 = computeB5(UT)
+        val UP = readRawPressure(oss)
+
+        val B6 = B5 - 4000L
+        var X1 = (B2.toLong() * ((B6 * B6) shr 12)) shr 11
+        var X2 = (AC2.toLong() * B6) shr 11
+        var X3 = X1 + X2
+        val B3 = (((AC1.toLong() * 4L + X3) shl oss) + 2L) shr 2
+
+        X1 = (AC3.toLong() * B6) shr 13
+        X2 = (B1.toLong() * ((B6 * B6) shr 12)) shr 16
+        X3 = ((X1 + X2) + 2L) shr 2
+        val B4 = (AC4.toLong() and 0xFFFFFFFFL) * (X3 + 32768L) ushr 15
+        val B7 = (UP - B3) * (50000L shr oss)
+
+        var p: Long = if (B7 < 0x80000000L) {
+            (B7 * 2L) / B4
+        } else {
+            (B7 / B4) * 2L
+        }
+
+        X1 = (p shr 8) * (p shr 8)
+        X1 = (X1 * 3038L) shr 16
+        X2 = (-7357L * p) shr 16
+        p  = p + ((X1 + X2 + 3791L) shr 4)
+
+        return p / 100.0
+    }
+}

--- a/jvm/periph-transport/pom.xml
+++ b/jvm/periph-transport/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it.uhde</groupId>
+        <artifactId>periph</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>periph-transport</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.pi4j</groupId>
+            <artifactId>pi4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.pi4j</groupId>
+            <artifactId>pi4j-plugin-raspberrypi</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.pi4j</groupId>
+            <artifactId>pi4j-plugin-linuxfs</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/jvm/periph-transport/src/main/java/it/uhde/periph/transport/I2CTransport.java
+++ b/jvm/periph-transport/src/main/java/it/uhde/periph/transport/I2CTransport.java
@@ -1,0 +1,74 @@
+package it.uhde.periph.transport;
+
+import com.pi4j.context.Context;
+import com.pi4j.io.i2c.I2C;
+
+import java.io.IOException;
+
+/**
+ * I²C transport backed by Pi4J (Linux /dev/i2c-N via the linuxfs plugin).
+ *
+ * <p>One instance represents one device address on one bus. Create a separate
+ * instance for every distinct address, including the I²C General Call address
+ * (0x00) when needed.
+ */
+public final class I2CTransport implements Transport {
+
+    private final I2C device;
+
+    /**
+     * Open an I²C device.
+     *
+     * @param pi4j    active Pi4J context (caller retains ownership)
+     * @param bus     I²C bus number (e.g. 1 for /dev/i2c-1)
+     * @param address 7-bit device address
+     */
+    public I2CTransport(Context pi4j, int bus, int address) {
+        var config = I2C.newConfigBuilder(pi4j)
+                .id("i2c-" + bus + "-" + Integer.toHexString(address))
+                .bus(bus)
+                .device(address)
+                .build();
+        this.device = pi4j.create(config);
+    }
+
+    @Override
+    public void write(byte[] data) throws IOException {
+        try {
+            device.write(data, 0, data.length);
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public byte[] read(int n) throws IOException {
+        try {
+            byte[] buf = new byte[n];
+            device.read(buf, 0, n);
+            return buf;
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Writes then reads as two separate bus transactions (stop + start between them).
+     * Pi4J's linuxfs plugin does not expose a true repeated-start for raw I²C;
+     * for chips that require it, use a platform-specific transport instead.
+     */
+    @Override
+    public byte[] writeRead(byte[] data, int n) throws IOException {
+        write(data);
+        return read(n);
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            device.close();
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/jvm/periph-transport/src/main/java/it/uhde/periph/transport/Transport.java
+++ b/jvm/periph-transport/src/main/java/it/uhde/periph/transport/Transport.java
@@ -1,0 +1,40 @@
+package it.uhde.periph.transport;
+
+import java.io.IOException;
+
+/**
+ * Represents one device on a bus. Each instance is bound to a single device address.
+ * Implementations wrap a platform-specific bus (e.g. Pi4J I²C).
+ */
+public interface Transport extends AutoCloseable {
+
+    /**
+     * Send bytes to the device.
+     *
+     * @param data bytes to write
+     * @throws IOException on bus error or no ACK
+     */
+    void write(byte[] data) throws IOException;
+
+    /**
+     * Read bytes from the device.
+     *
+     * @param n number of bytes to read
+     * @return bytes received
+     * @throws IOException on bus error or no ACK
+     */
+    byte[] read(int n) throws IOException;
+
+    /**
+     * Write then read without releasing the bus between phases.
+     *
+     * @param data bytes to write (typically a register address)
+     * @param n    number of bytes to read back
+     * @return bytes received
+     * @throws IOException on bus error or no ACK
+     */
+    byte[] writeRead(byte[] data, int n) throws IOException;
+
+    @Override
+    void close() throws IOException;
+}

--- a/jvm/periph-transport/src/main/java/module-info.java
+++ b/jvm/periph-transport/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module it.uhde.periph.transport {
+    exports it.uhde.periph.transport;
+    requires com.pi4j;
+}

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>it.uhde</groupId>
+    <artifactId>periph</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>periph-transport</module>
+        <module>periph-java</module>
+        <module>periph-kotlin</module>
+        <module>periph-groovy</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <pi4j.version>2.7.0</pi4j.version>
+        <kotlin.version>2.0.21</kotlin.version>
+        <groovy.version>4.0.24</groovy.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.pi4j</groupId>
+                <artifactId>pi4j-core</artifactId>
+                <version>${pi4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.pi4j</groupId>
+                <artifactId>pi4j-plugin-raspberrypi</artifactId>
+                <version>${pi4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.pi4j</groupId>
+                <artifactId>pi4j-plugin-linuxfs</artifactId>
+                <version>${pi4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>it.uhde</groupId>
+                <artifactId>periph-transport</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.13.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -17,7 +17,7 @@
     </modules>
 
     <properties>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <pi4j.version>2.7.0</pi4j.version>
         <kotlin.version>2.0.21</kotlin.version>

--- a/jvm/test.sh
+++ b/jvm/test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Usage:
+#   ./test.sh <category>/<chip> [--lang java|kotlin|groovy]
+#
+# Runs a JVM (jbang) hardware test on the Pi via Pi4J.
+# Reads testconfig from the same directory if present.
+# Defaults to Java; pass --lang kotlin or --lang groovy for the other variants.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# --- load local config ---------------------------------------------------
+CONFIG="$SCRIPT_DIR/testconfig"
+if [ -f "$CONFIG" ]; then
+    # shellcheck source=/dev/null
+    source "$CONFIG"
+else
+    echo "WARNING: $CONFIG not found. Using defaults — copy testconfig.example to testconfig."
+fi
+
+I2C_BUS="${I2C_BUS:-1}"
+
+# --- parse args ----------------------------------------------------------
+TARGET="${1:-}"
+if [ -z "$TARGET" ]; then
+    echo "Usage: $0 <category>/<chip> [--lang java|kotlin|groovy]"
+    echo "  e.g. $0 adc_dac/mcp4725"
+    echo "       $0 adc_dac/mcp4725 --lang kotlin"
+    exit 1
+fi
+
+LANG_OPT="java"
+if [ "${2:-}" = "--lang" ]; then
+    LANG_OPT="${3:-java}"
+fi
+
+CHIP="${TARGET##*/}"
+CATEGORY="${TARGET%/*}"
+
+# --- resolve I2C address -------------------------------------------------
+if [ -z "${I2C_ADDR:-}" ]; then
+    I2C_ADDR=$(awk -v c="$CHIP" '$1==c{print $2; exit}' "$SCRIPT_DIR/../chip_defaults" 2>/dev/null || true)
+    if [ -z "${I2C_ADDR:-}" ]; then
+        echo "ERROR: I2C_ADDR not set in testconfig and no default found for '$CHIP' in chip_defaults" >&2
+        exit 1
+    fi
+fi
+
+# --- derive class name and extension: mcp4725 → Mcp4725Test --------------
+CHIP_CLASS="$(echo "${CHIP:0:1}" | tr '[:lower:]' '[:upper:]')${CHIP:1}Test"
+
+case "$LANG_OPT" in
+    kotlin|kt) EXT="kt" ;;
+    groovy)    EXT="groovy" ;;
+    *)         EXT="java" ;;
+esac
+
+TEST_FILE="$SCRIPT_DIR/tests/$CATEGORY/$CHIP/${CHIP_CLASS}.${EXT}"
+
+if [ ! -f "$TEST_FILE" ]; then
+    echo "ERROR: test file not found: $TEST_FILE"
+    exit 1
+fi
+
+# --- run -----------------------------------------------------------------
+echo "=== Running $TARGET on JVM/$LANG_OPT / Pi4J (I2C bus $I2C_BUS, addr $I2C_ADDR) ==="
+I2C_BUS="$I2C_BUS" I2C_ADDR="$I2C_ADDR" jbang "$TEST_FILE"

--- a/jvm/testconfig.example
+++ b/jvm/testconfig.example
@@ -1,0 +1,9 @@
+# Periph JVM test configuration
+# Copy this file to testconfig and fill in your values.
+# testconfig is gitignored — never commit it.
+
+# I²C bus number (e.g. 1 for /dev/i2c-1)
+I2C_BUS=1
+
+# Device I²C address in hex (optional — falls back to chip_defaults)
+# I2C_ADDR=0x60

--- a/jvm/tests/adc_dac/mcp4725/Mcp4725Test.groovy
+++ b/jvm/tests/adc_dac/mcp4725/Mcp4725Test.groovy
@@ -1,0 +1,82 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import groovy.transform.Field
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.adc_dac.Mcp4725Full
+
+@Field int passed = 0
+@Field int failed = 0
+
+def checkTrue(String label, boolean condition) {
+    if (condition) { println("PASS $label"); passed++ }
+    else           { println("FAIL $label"); failed++ }
+}
+
+int bus  = (System.getenv('I2C_BUS')  ?: '1').toInteger()
+int addr = Integer.parseInt((System.getenv('I2C_ADDR') ?: '0x60').replaceFirst(/^0[xX]/, ''), 16)
+
+def pi4j = Pi4J.newAutoContext()
+try {
+    def transport   = new I2CTransport(pi4j, bus, addr)
+    def gcTransport = new I2CTransport(pi4j, bus, 0x00)
+    try {
+        def dac = new Mcp4725Full(transport, gcTransport)
+
+        dac.setVoltage(0.5)
+        checkTrue('setVoltage(0.5) accepted', true)
+
+        dac.setRaw(2048)
+        checkTrue('setRaw(2048) accepted', true)
+
+        dac.setVoltageEeprom(0.5)
+        checkTrue('setVoltageEeprom(0.5) accepted', true)
+
+        dac.setRawEeprom(2048)
+        checkTrue('setRawEeprom(2048) accepted', true)
+
+        Thread.sleep(50)
+
+        def state = dac.read()
+        checkTrue('read: code in range',            state.code >= 0 && state.code <= 4095)
+        checkTrue('read: voltageFraction in range', state.voltageFraction >= 0.0 && state.voltageFraction <= 1.0)
+        checkTrue('read: powerDown in range',       state.powerDown >= 0 && state.powerDown <= 3)
+        checkTrue('read: eepromCode in range',      state.eepromCode >= 0 && state.eepromCode <= 4095)
+        checkTrue('read: eepromPowerDown in range', state.eepromPowerDown >= 0 && state.eepromPowerDown <= 3)
+
+        dac.setPowerDown(0)
+        checkTrue('setPowerDown(0 normal) accepted', true)
+
+        dac.setPowerDown(1)
+        checkTrue('setPowerDown(1 1kΩ) accepted', true)
+
+        dac.setPowerDown(2)
+        checkTrue('setPowerDown(2 100kΩ) accepted', true)
+
+        dac.setPowerDown(3)
+        checkTrue('setPowerDown(3 500kΩ) accepted', true)
+
+        dac.wakeUp()
+        checkTrue('wakeUp accepted', true)
+
+        dac.reset()
+        checkTrue('reset accepted', true)
+
+        dac.isEepromReady()
+        checkTrue('isEepromReady accepted', true)
+
+    } finally {
+        transport.close()
+        gcTransport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}
+
+println("===DONE: ${passed} passed, ${failed} failed===")
+System.exit(failed == 0 ? 0 : 1)

--- a/jvm/tests/adc_dac/mcp4725/Mcp4725Test.java
+++ b/jvm/tests/adc_dac/mcp4725/Mcp4725Test.java
@@ -1,0 +1,82 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.adc_dac.Mcp4725Full;
+
+public class Mcp4725Test {
+
+    static int passed = 0;
+    static int failed = 0;
+
+    static void checkTrue(String label, boolean condition) {
+        if (condition) { System.out.println("PASS " + label); passed++; }
+        else           { System.out.println("FAIL " + label); failed++; }
+    }
+
+    public static void main(String[] args) throws Exception {
+        int bus  = Integer.parseInt(System.getenv().getOrDefault("I2C_BUS", "1"));
+        int addr = Integer.parseInt(
+                System.getenv().getOrDefault("I2C_ADDR", "0x60").replaceFirst("^0[xX]", ""), 16);
+
+        var pi4j = Pi4J.newAutoContext();
+        try (var transport   = new I2CTransport(pi4j, bus, addr);
+             var gcTransport = new I2CTransport(pi4j, bus, 0x00)) {
+
+            var dac = new Mcp4725Full(transport, gcTransport);
+
+            dac.setVoltage(0.5);
+            checkTrue("setVoltage(0.5) accepted", true);
+
+            dac.setRaw(2048);
+            checkTrue("setRaw(2048) accepted", true);
+
+            dac.setVoltageEeprom(0.5);
+            checkTrue("setVoltageEeprom(0.5) accepted", true);
+
+            dac.setRawEeprom(2048);
+            checkTrue("setRawEeprom(2048) accepted", true);
+
+            Thread.sleep(50);
+
+            var state = dac.read();
+            checkTrue("read: code in range",            state.code() >= 0 && state.code() <= 4095);
+            checkTrue("read: voltageFraction in range", state.voltageFraction() >= 0.0 && state.voltageFraction() <= 1.0);
+            checkTrue("read: powerDown in range",       state.powerDown() >= 0 && state.powerDown() <= 3);
+            checkTrue("read: eepromCode in range",      state.eepromCode() >= 0 && state.eepromCode() <= 4095);
+            checkTrue("read: eepromPowerDown in range", state.eepromPowerDown() >= 0 && state.eepromPowerDown() <= 3);
+
+            dac.setPowerDown(0);
+            checkTrue("setPowerDown(0 normal) accepted", true);
+
+            dac.setPowerDown(1);
+            checkTrue("setPowerDown(1 1kΩ) accepted", true);
+
+            dac.setPowerDown(2);
+            checkTrue("setPowerDown(2 100kΩ) accepted", true);
+
+            dac.setPowerDown(3);
+            checkTrue("setPowerDown(3 500kΩ) accepted", true);
+
+            dac.wakeUp();
+            checkTrue("wakeUp accepted", true);
+
+            dac.reset();
+            checkTrue("reset accepted", true);
+
+            dac.isEepromReady();
+            checkTrue("isEepromReady accepted", true);
+
+        } finally {
+            pi4j.shutdown();
+        }
+
+        System.out.printf("===DONE: %d passed, %d failed===%n", passed, failed);
+        System.exit(failed == 0 ? 0 : 1);
+    }
+}

--- a/jvm/tests/adc_dac/mcp4725/Mcp4725Test.kt
+++ b/jvm/tests/adc_dac/mcp4725/Mcp4725Test.kt
@@ -1,0 +1,79 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.adc_dac.Mcp4725Full
+
+var passed = 0
+var failed = 0
+
+fun checkTrue(label: String, condition: Boolean) {
+    if (condition) { println("PASS $label"); passed++ }
+    else           { println("FAIL $label"); failed++ }
+}
+
+fun main() {
+    val bus  = System.getenv("I2C_BUS")?.toInt() ?: 1
+    val addr = System.getenv("I2C_ADDR")?.removePrefix("0x")?.removePrefix("0X")?.toInt(16) ?: 0x60
+
+    val pi4j = Pi4J.newAutoContext()
+    try {
+        I2CTransport(pi4j, bus, addr).use { transport ->
+        I2CTransport(pi4j, bus, 0x00).use { gcTransport ->
+
+            val dac = Mcp4725Full(transport, gcTransport)
+
+            dac.setVoltage(0.5)
+            checkTrue("setVoltage(0.5) accepted", true)
+
+            dac.setRaw(2048)
+            checkTrue("setRaw(2048) accepted", true)
+
+            dac.setVoltageEeprom(0.5)
+            checkTrue("setVoltageEeprom(0.5) accepted", true)
+
+            dac.setRawEeprom(2048)
+            checkTrue("setRawEeprom(2048) accepted", true)
+
+            Thread.sleep(50)
+
+            val state = dac.read()
+            checkTrue("read: code in range",            state.code in 0..4095)
+            checkTrue("read: voltageFraction in range", state.voltageFraction in 0.0..1.0)
+            checkTrue("read: powerDown in range",       state.powerDown in 0..3)
+            checkTrue("read: eepromCode in range",      state.eepromCode in 0..4095)
+            checkTrue("read: eepromPowerDown in range", state.eepromPowerDown in 0..3)
+
+            dac.setPowerDown(0)
+            checkTrue("setPowerDown(0 normal) accepted", true)
+
+            dac.setPowerDown(1)
+            checkTrue("setPowerDown(1 1kΩ) accepted", true)
+
+            dac.setPowerDown(2)
+            checkTrue("setPowerDown(2 100kΩ) accepted", true)
+
+            dac.setPowerDown(3)
+            checkTrue("setPowerDown(3 500kΩ) accepted", true)
+
+            dac.wakeUp()
+            checkTrue("wakeUp accepted", true)
+
+            dac.reset()
+            checkTrue("reset accepted", true)
+
+            dac.isEepromReady()
+            checkTrue("isEepromReady accepted", true)
+        }}
+    } finally {
+        pi4j.shutdown()
+    }
+
+    println("===DONE: $passed passed, $failed failed===")
+    System.exit(if (failed == 0) 0 else 1)
+}

--- a/jvm/tests/power/ina219/Ina219Test.groovy
+++ b/jvm/tests/power/ina219/Ina219Test.groovy
@@ -1,0 +1,88 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import groovy.transform.Field
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina219Full
+
+@Field int passed = 0
+@Field int failed = 0
+
+def checkTrue(String label, boolean condition) {
+    if (condition) { println("PASS $label"); passed++ }
+    else           { println("FAIL $label"); failed++ }
+}
+
+int bus  = (System.getenv('I2C_BUS')  ?: '1').toInteger()
+int addr = Integer.parseInt((System.getenv('I2C_ADDR') ?: '0x40').replaceFirst(/^0[xX]/, ''), 16)
+
+def pi4j = Pi4J.newAutoContext()
+try {
+    def transport = new I2CTransport(pi4j, bus, addr)
+    try {
+        def ina = new Ina219Full(transport, 0.1d, 2.0d)
+
+        // voltage() should return a value in the physically plausible range 0–36 V
+        double v = ina.voltage()
+        checkTrue('voltage() in range [0, 36] V', v >= 0.0 && v <= 36.0)
+
+        // shuntVoltage() should return a finite float
+        double vs = ina.shuntVoltage()
+        checkTrue('shuntVoltage() is finite', !vs.isNaN() && !vs.isInfinite())
+
+        // current() should return a finite float (signed)
+        double i = ina.current()
+        checkTrue('current() is finite', !i.isNaN() && !i.isInfinite())
+
+        // power() should return a finite float
+        double p = ina.power()
+        checkTrue('power() is finite', !p.isNaN() && !p.isInfinite())
+
+        // configure() should be accepted without throwing
+        ina.configure(Ina219Full.BRNG_32V, Ina219Full.PGA_8,
+                      Ina219Full.ADC_12BIT, Ina219Full.ADC_12BIT,
+                      Ina219Full.MODE_SHUNT_BUS_CONT)
+        checkTrue('configure() accepted', true)
+
+        // conversionReady() should return a boolean
+        ina.conversionReady()
+        checkTrue('conversionReady() accepted', true)
+
+        // overflow() should return a boolean
+        ina.overflow()
+        checkTrue('overflow() accepted', true)
+
+        // reset() should be accepted without throwing
+        ina.reset()
+        checkTrue('reset() accepted', true)
+        Thread.sleep(5)
+
+        // shutdown() should be accepted without throwing
+        ina.shutdown()
+        checkTrue('shutdown() accepted', true)
+        Thread.sleep(5)
+
+        // wake() should restore the device
+        ina.wake()
+        checkTrue('wake() accepted', true)
+        Thread.sleep(5)
+
+        // After wake, voltage should still be in range
+        double vAfterWake = ina.voltage()
+        checkTrue('voltage() after wake in range [0, 36] V',
+                  vAfterWake >= 0.0 && vAfterWake <= 36.0)
+
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}
+
+println("===DONE: ${passed} passed, ${failed} failed===")
+System.exit(failed == 0 ? 0 : 1)

--- a/jvm/tests/power/ina219/Ina219Test.java
+++ b/jvm/tests/power/ina219/Ina219Test.java
@@ -1,0 +1,89 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.power.Ina219Full;
+
+public class Ina219Test {
+
+    static int passed = 0;
+    static int failed = 0;
+
+    static void checkTrue(String label, boolean condition) {
+        if (condition) { System.out.println("PASS " + label); passed++; }
+        else           { System.out.println("FAIL " + label); failed++; }
+    }
+
+    public static void main(String[] args) throws Exception {
+        int bus  = Integer.parseInt(System.getenv().getOrDefault("I2C_BUS", "1"));
+        int addr = Integer.parseInt(
+                System.getenv().getOrDefault("I2C_ADDR", "0x40").replaceFirst("^0[xX]", ""), 16);
+
+        var pi4j = Pi4J.newAutoContext();
+        try (var transport = new I2CTransport(pi4j, bus, addr)) {
+
+            var ina = new Ina219Full(transport, 0.1, 2.0);
+
+            // voltage() should return a value in the physically plausible range 0–36 V
+            double v = ina.voltage();
+            checkTrue("voltage() in range [0, 36] V", v >= 0.0 && v <= 36.0);
+
+            // shuntVoltage() should return a float (any finite value accepted)
+            double vs = ina.shuntVoltage();
+            checkTrue("shuntVoltage() is finite", Double.isFinite(vs));
+
+            // current() should return a float (signed, any finite value)
+            double i = ina.current();
+            checkTrue("current() is finite", Double.isFinite(i));
+
+            // power() should return a non-negative float
+            double p = ina.power();
+            checkTrue("power() is finite", Double.isFinite(p));
+
+            // configure() should be accepted without throwing
+            ina.configure(Ina219Full.BRNG_32V, Ina219Full.PGA_8,
+                          Ina219Full.ADC_12BIT, Ina219Full.ADC_12BIT,
+                          Ina219Full.MODE_SHUNT_BUS_CONT);
+            checkTrue("configure() accepted", true);
+
+            // conversionReady() should return a boolean
+            ina.conversionReady();
+            checkTrue("conversionReady() accepted", true);
+
+            // overflow() should return a boolean
+            ina.overflow();
+            checkTrue("overflow() accepted", true);
+
+            // reset() should be accepted without throwing
+            ina.reset();
+            checkTrue("reset() accepted", true);
+            Thread.sleep(5);
+
+            // shutdown() should be accepted without throwing
+            ina.shutdown();
+            checkTrue("shutdown() accepted", true);
+            Thread.sleep(5);
+
+            // wake() should restore the device
+            ina.wake();
+            checkTrue("wake() accepted", true);
+            Thread.sleep(5);
+
+            // After wake, voltage should still be in range
+            double vAfterWake = ina.voltage();
+            checkTrue("voltage() after wake in range [0, 36] V",
+                      vAfterWake >= 0.0 && vAfterWake <= 36.0);
+
+        } finally {
+            pi4j.shutdown();
+        }
+
+        System.out.printf("===DONE: %d passed, %d failed===%n", passed, failed);
+        System.exit(failed == 0 ? 0 : 1);
+    }
+}

--- a/jvm/tests/power/ina219/Ina219Test.kt
+++ b/jvm/tests/power/ina219/Ina219Test.kt
@@ -1,0 +1,86 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina219Full
+
+var passed = 0
+var failed = 0
+
+fun checkTrue(label: String, condition: Boolean) {
+    if (condition) { println("PASS $label"); passed++ }
+    else           { println("FAIL $label"); failed++ }
+}
+
+fun main() {
+    val bus  = System.getenv("I2C_BUS")?.toInt() ?: 1
+    val addr = System.getenv("I2C_ADDR")?.removePrefix("0x")?.removePrefix("0X")?.toInt(16) ?: 0x40
+
+    val pi4j = Pi4J.newAutoContext()
+    try {
+        I2CTransport(pi4j, bus, addr).use { transport ->
+
+            val ina = Ina219Full(transport, 0.1, 2.0)
+
+            // voltage() should return a value in the physically plausible range 0–36 V
+            val v = ina.voltage()
+            checkTrue("voltage() in range [0, 36] V", v >= 0.0 && v <= 36.0)
+
+            // shuntVoltage() should return a finite float
+            val vs = ina.shuntVoltage()
+            checkTrue("shuntVoltage() is finite", vs.isFinite())
+
+            // current() should return a finite float (signed)
+            val i = ina.current()
+            checkTrue("current() is finite", i.isFinite())
+
+            // power() should return a finite float
+            val p = ina.power()
+            checkTrue("power() is finite", p.isFinite())
+
+            // configure() should be accepted without throwing
+            ina.configure(Ina219Full.BRNG_32V, Ina219Full.PGA_8,
+                          Ina219Full.ADC_12BIT, Ina219Full.ADC_12BIT,
+                          Ina219Full.MODE_SHUNT_BUS_CONT)
+            checkTrue("configure() accepted", true)
+
+            // conversionReady() should return a boolean
+            ina.conversionReady()
+            checkTrue("conversionReady() accepted", true)
+
+            // overflow() should return a boolean
+            ina.overflow()
+            checkTrue("overflow() accepted", true)
+
+            // reset() should be accepted without throwing
+            ina.reset()
+            checkTrue("reset() accepted", true)
+            Thread.sleep(5)
+
+            // shutdown() should be accepted without throwing
+            ina.shutdown()
+            checkTrue("shutdown() accepted", true)
+            Thread.sleep(5)
+
+            // wake() should restore the device
+            ina.wake()
+            checkTrue("wake() accepted", true)
+            Thread.sleep(5)
+
+            // After wake, voltage should still be in range
+            val vAfterWake = ina.voltage()
+            checkTrue("voltage() after wake in range [0, 36] V",
+                      vAfterWake >= 0.0 && vAfterWake <= 36.0)
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+
+    println("===DONE: $passed passed, $failed failed===")
+    System.exit(if (failed == 0) 0 else 1)
+}

--- a/jvm/tests/power/ina226/Ina226Test.groovy
+++ b/jvm/tests/power/ina226/Ina226Test.groovy
@@ -1,0 +1,92 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import groovy.transform.Field
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina226Full
+
+@Field int passed = 0
+@Field int failed = 0
+
+def checkTrue(String label, boolean condition) {
+    if (condition) { println("PASS $label"); passed++ }
+    else           { println("FAIL $label"); failed++ }
+}
+
+int bus  = (System.getenv('I2C_BUS')  ?: '1').toInteger()
+int addr = Integer.parseInt((System.getenv('I2C_ADDR') ?: '0x40').replaceFirst(/^0[xX]/, ''), 16)
+
+def pi4j = Pi4J.newAutoContext()
+try {
+    def transport = new I2CTransport(pi4j, bus, addr)
+    try {
+        def ina = new Ina226Full(transport, 0.1d, 2.0d)
+
+        // --- Basic measurements ---
+        double v = ina.voltage()
+        checkTrue('voltage() in range 0–36 V', v >= 0.0d && v <= 36.0d)
+
+        double vs = ina.shuntVoltage()
+        checkTrue('shuntVoltage() is finite', !vs.isNaN() && !vs.isInfinite())
+
+        double c = ina.current()
+        checkTrue('current() is finite', !c.isNaN() && !c.isInfinite())
+
+        double p = ina.power()
+        checkTrue('power() is finite', !p.isNaN() && !p.isInfinite())
+
+        // --- Configuration ---
+        ina.configure(Ina226Full.AVG_128, Ina226Full.CT_1100US,
+                      Ina226Full.CT_1100US, Ina226Full.MODE_SHUNT_BUS_CONT)
+        checkTrue('configure() accepted', true)
+
+        Thread.sleep(300)  // allow conversion with 128 averages at 1.1 ms each
+
+        // --- Conversion ready and overflow flags ---
+        ina.conversionReady()
+        checkTrue('conversionReady() accepted', true)
+
+        ina.overflow()
+        checkTrue('overflow() accepted', true)
+
+        // --- Alert ---
+        ina.setAlert(Ina226Full.SOL, 0.1d)
+        checkTrue('setAlert(SOL, 0.1) accepted', true)
+
+        ina.alertFlags()
+        checkTrue('alertFlags() accepted', true)
+
+        // --- Reset ---
+        ina.reset()
+        checkTrue('reset() accepted', true)
+
+        // --- Shutdown / wake ---
+        ina.shutdown()
+        checkTrue('shutdown() accepted', true)
+
+        Thread.sleep(10)
+
+        ina.wake()
+        checkTrue('wake() accepted', true)
+
+        // --- Device identification ---
+        int mfrId = ina.manufacturerId()
+        checkTrue('manufacturerId() == 0x5449', mfrId == 0x5449)
+
+        int dieId = ina.dieId()
+        checkTrue('dieId() == 0x2260', dieId == 0x2260)
+
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}
+
+println("===DONE: ${passed} passed, ${failed} failed===")
+System.exit(failed == 0 ? 0 : 1)

--- a/jvm/tests/power/ina226/Ina226Test.java
+++ b/jvm/tests/power/ina226/Ina226Test.java
@@ -1,0 +1,93 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.power.Ina226Full;
+
+public class Ina226Test {
+
+    static int passed = 0;
+    static int failed = 0;
+
+    static void checkTrue(String label, boolean condition) {
+        if (condition) { System.out.println("PASS " + label); passed++; }
+        else           { System.out.println("FAIL " + label); failed++; }
+    }
+
+    public static void main(String[] args) throws Exception {
+        int bus  = Integer.parseInt(System.getenv().getOrDefault("I2C_BUS", "1"));
+        int addr = Integer.parseInt(
+                System.getenv().getOrDefault("I2C_ADDR", "0x40").replaceFirst("^0[xX]", ""), 16);
+
+        var pi4j = Pi4J.newAutoContext();
+        try (var transport = new I2CTransport(pi4j, bus, addr)) {
+
+            var ina = new Ina226Full(transport, 0.1, 2.0);
+
+            // --- Basic measurements ---
+            double v = ina.voltage();
+            checkTrue("voltage() in range 0–36 V", v >= 0.0 && v <= 36.0);
+
+            double vs = ina.shuntVoltage();
+            checkTrue("shuntVoltage() is finite", Double.isFinite(vs));
+
+            double c = ina.current();
+            checkTrue("current() is finite", Double.isFinite(c));
+
+            double p = ina.power();
+            checkTrue("power() is finite", Double.isFinite(p));
+
+            // --- Configuration ---
+            ina.configure(Ina226Full.AVG_128, Ina226Full.CT_1100US,
+                          Ina226Full.CT_1100US, Ina226Full.MODE_SHUNT_BUS_CONT);
+            checkTrue("configure() accepted", true);
+
+            Thread.sleep(300);  // allow conversion with 128 averages at 1.1 ms each
+
+            // --- Conversion ready and overflow flags ---
+            boolean ready = ina.conversionReady();
+            checkTrue("conversionReady() accepted", true);
+
+            boolean ovf = ina.overflow();
+            checkTrue("overflow() accepted", true);
+
+            // --- Alert ---
+            ina.setAlert(Ina226Full.SOL, 0.1);
+            checkTrue("setAlert(SOL, 0.1) accepted", true);
+
+            int flags = ina.alertFlags();
+            checkTrue("alertFlags() accepted", true);
+
+            // --- Reset ---
+            ina.reset();
+            checkTrue("reset() accepted", true);
+
+            // --- Shutdown / wake ---
+            ina.shutdown();
+            checkTrue("shutdown() accepted", true);
+
+            Thread.sleep(10);
+
+            ina.wake();
+            checkTrue("wake() accepted", true);
+
+            // --- Device identification ---
+            int mfrId = ina.manufacturerId();
+            checkTrue("manufacturerId() == 0x5449", mfrId == 0x5449);
+
+            int dieId = ina.dieId();
+            checkTrue("dieId() == 0x2260", dieId == 0x2260);
+
+        } finally {
+            pi4j.shutdown();
+        }
+
+        System.out.printf("===DONE: %d passed, %d failed===%n", passed, failed);
+        System.exit(failed == 0 ? 0 : 1);
+    }
+}

--- a/jvm/tests/power/ina226/Ina226Test.kt
+++ b/jvm/tests/power/ina226/Ina226Test.kt
@@ -1,0 +1,90 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina226Full
+
+var passed = 0
+var failed = 0
+
+fun checkTrue(label: String, condition: Boolean) {
+    if (condition) { println("PASS $label"); passed++ }
+    else           { println("FAIL $label"); failed++ }
+}
+
+fun main() {
+    val bus  = System.getenv("I2C_BUS")?.toInt() ?: 1
+    val addr = System.getenv("I2C_ADDR")?.removePrefix("0x")?.removePrefix("0X")?.toInt(16) ?: 0x40
+
+    val pi4j = Pi4J.newAutoContext()
+    try {
+        I2CTransport(pi4j, bus, addr).use { transport ->
+
+            val ina = Ina226Full(transport, 0.1, 2.0)
+
+            // --- Basic measurements ---
+            val v = ina.voltage()
+            checkTrue("voltage() in range 0–36 V", v in 0.0..36.0)
+
+            val vs = ina.shuntVoltage()
+            checkTrue("shuntVoltage() is finite", vs.isFinite())
+
+            val c = ina.current()
+            checkTrue("current() is finite", c.isFinite())
+
+            val p = ina.power()
+            checkTrue("power() is finite", p.isFinite())
+
+            // --- Configuration ---
+            ina.configure(Ina226Full.AVG_128, Ina226Full.CT_1100US,
+                          Ina226Full.CT_1100US, Ina226Full.MODE_SHUNT_BUS_CONT)
+            checkTrue("configure() accepted", true)
+
+            Thread.sleep(300)  // allow conversion with 128 averages at 1.1 ms each
+
+            // --- Conversion ready and overflow flags ---
+            ina.conversionReady()
+            checkTrue("conversionReady() accepted", true)
+
+            ina.overflow()
+            checkTrue("overflow() accepted", true)
+
+            // --- Alert ---
+            ina.setAlert(Ina226Full.SOL, 0.1)
+            checkTrue("setAlert(SOL, 0.1) accepted", true)
+
+            ina.alertFlags()
+            checkTrue("alertFlags() accepted", true)
+
+            // --- Reset ---
+            ina.reset()
+            checkTrue("reset() accepted", true)
+
+            // --- Shutdown / wake ---
+            ina.shutdown()
+            checkTrue("shutdown() accepted", true)
+
+            Thread.sleep(10)
+
+            ina.wake()
+            checkTrue("wake() accepted", true)
+
+            // --- Device identification ---
+            val mfrId = ina.manufacturerId()
+            checkTrue("manufacturerId() == 0x5449", mfrId == 0x5449)
+
+            val dieId = ina.dieId()
+            checkTrue("dieId() == 0x2260", dieId == 0x2260)
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+
+    println("===DONE: $passed passed, $failed failed===")
+    System.exit(if (failed == 0) 0 else 1)
+}

--- a/jvm/tests/power/ina3221/Ina3221Test.groovy
+++ b/jvm/tests/power/ina3221/Ina3221Test.groovy
@@ -1,0 +1,112 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import groovy.transform.Field
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina3221Full
+
+@Field int passed = 0
+@Field int failed = 0
+
+def checkTrue(String label, boolean condition) {
+    if (condition) { println("PASS $label"); passed++ }
+    else           { println("FAIL $label"); failed++ }
+}
+
+int bus  = (System.getenv('I2C_BUS')  ?: '1').toInteger()
+int addr = Integer.parseInt((System.getenv('I2C_ADDR') ?: '0x40').replaceFirst(/^0[xX]/, ''), 16)
+
+def pi4j = Pi4J.newAutoContext()
+try {
+    def transport = new I2CTransport(pi4j, bus, addr)
+    try {
+        def ina = new Ina3221Full(transport)
+
+        // --- Minimal methods: all three channels ---
+        (1..3).each { ch ->
+            def v = ina.voltage(ch)
+            checkTrue("voltage(ch${ch}) in 0–26 V", v >= 0.0 && v <= 26.0)
+
+            def sv = ina.shuntVoltage(ch)
+            checkTrue("shuntVoltage(ch${ch}) is finite", sv != Double.NaN && !sv.infinite)
+
+            def i = ina.current(ch)
+            checkTrue("current(ch${ch}) is finite", i != Double.NaN && !i.infinite)
+
+            def p = ina.power(ch)
+            checkTrue("power(ch${ch}) is finite", p != Double.NaN && !p.infinite)
+        }
+
+        // --- configure() ---
+        ina.configure(1, 4, 4, Ina3221Full.MODE_SHUNT_BUS_CONT)
+        checkTrue('configure() accepted', true)
+
+        // --- enableChannel / channelEnabled ---
+        ina.enableChannel(1, true)
+        checkTrue('enableChannel(1, true) accepted', true)
+
+        def en = ina.channelEnabled(1)
+        checkTrue('channelEnabled(1) returns boolean', en instanceof Boolean)
+
+        // --- conversionReady ---
+        def cvrf = ina.conversionReady()
+        checkTrue('conversionReady() returns boolean', cvrf instanceof Boolean)
+
+        // --- Alert limits ---
+        ina.setCriticalAlert(1, 0.1)
+        checkTrue('setCriticalAlert(1, 0.1) accepted', true)
+
+        ina.setWarningAlert(1, 0.08)
+        checkTrue('setWarningAlert(1, 0.08) accepted', true)
+
+        // --- alertFlags ---
+        def flags = ina.alertFlags()
+        checkTrue('alertFlags() in 0–0xFFFF', flags >= 0 && flags <= 0xFFFF)
+
+        // --- power-valid limits ---
+        ina.setPowerValidLimits(5.5, 4.5)
+        checkTrue('setPowerValidLimits(5.5, 4.5) accepted', true)
+
+        // --- summation ---
+        ina.setSummationChannels([1, 2, 3] as int[], 0.1)
+        checkTrue('setSummationChannels([1,2,3], 0.1) accepted', true)
+
+        def sumV = ina.summationValue()
+        checkTrue('summationValue() is finite', sumV != Double.NaN && !sumV.infinite)
+
+        // --- powerValid ---
+        def pv = ina.powerValid()
+        checkTrue('powerValid() returns boolean', pv instanceof Boolean)
+
+        // --- manufacturerId / dieId ---
+        def mfr = ina.manufacturerId()
+        checkTrue('manufacturerId() == 0x5449', mfr == 0x5449)
+
+        def die = ina.dieId()
+        checkTrue('dieId() == 0x3220', die == 0x3220)
+
+        // --- shutdown / wake ---
+        ina.shutdown()
+        checkTrue('shutdown() accepted', true)
+
+        ina.wake()
+        checkTrue('wake() accepted', true)
+
+        // --- reset ---
+        ina.reset()
+        checkTrue('reset() accepted', true)
+
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}
+
+println("===DONE: ${passed} passed, ${failed} failed===")
+System.exit(failed == 0 ? 0 : 1)

--- a/jvm/tests/power/ina3221/Ina3221Test.java
+++ b/jvm/tests/power/ina3221/Ina3221Test.java
@@ -1,0 +1,113 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.power.Ina3221Full;
+
+public class Ina3221Test {
+
+    static int passed = 0;
+    static int failed = 0;
+
+    static void checkTrue(String label, boolean condition) {
+        if (condition) { System.out.println("PASS " + label); passed++; }
+        else           { System.out.println("FAIL " + label); failed++; }
+    }
+
+    public static void main(String[] args) throws Exception {
+        int bus  = Integer.parseInt(System.getenv().getOrDefault("I2C_BUS", "1"));
+        int addr = Integer.parseInt(
+                System.getenv().getOrDefault("I2C_ADDR", "0x40").replaceFirst("^0[xX]", ""), 16);
+
+        var pi4j = Pi4J.newAutoContext();
+        try (var transport = new I2CTransport(pi4j, bus, addr)) {
+
+            var ina = new Ina3221Full(transport);
+
+            // --- Minimal methods: all three channels ---
+            for (int ch = 1; ch <= 3; ch++) {
+                double v = ina.voltage(ch);
+                checkTrue("voltage(ch" + ch + ") in 0–26 V", v >= 0.0 && v <= 26.0);
+
+                double sv = ina.shuntVoltage(ch);
+                checkTrue("shuntVoltage(ch" + ch + ") is finite", Double.isFinite(sv));
+
+                double i = ina.current(ch);
+                checkTrue("current(ch" + ch + ") is finite", Double.isFinite(i));
+
+                double p = ina.power(ch);
+                checkTrue("power(ch" + ch + ") is finite", Double.isFinite(p));
+            }
+
+            // --- configure() ---
+            ina.configure(1, 4, 4, Ina3221Full.MODE_SHUNT_BUS_CONT);
+            checkTrue("configure() accepted", true);
+
+            // --- enableChannel / channelEnabled ---
+            ina.enableChannel(1, true);
+            checkTrue("enableChannel(1, true) accepted", true);
+
+            boolean en = ina.channelEnabled(1);
+            checkTrue("channelEnabled(1) returns boolean", en == true || en == false);
+
+            // --- conversionReady ---
+            boolean cvrf = ina.conversionReady();
+            checkTrue("conversionReady() returns boolean", cvrf == true || cvrf == false);
+
+            // --- Alert limits ---
+            ina.setCriticalAlert(1, 0.1);
+            checkTrue("setCriticalAlert(1, 0.1) accepted", true);
+
+            ina.setWarningAlert(1, 0.08);
+            checkTrue("setWarningAlert(1, 0.08) accepted", true);
+
+            // --- alertFlags ---
+            int flags = ina.alertFlags();
+            checkTrue("alertFlags() returns int", flags >= 0 && flags <= 0xFFFF);
+
+            // --- power-valid limits ---
+            ina.setPowerValidLimits(5.5, 4.5);
+            checkTrue("setPowerValidLimits(5.5, 4.5) accepted", true);
+
+            // --- summation ---
+            ina.setSummationChannels(new int[]{1, 2, 3}, 0.1);
+            checkTrue("setSummationChannels([1,2,3], 0.1) accepted", true);
+
+            double sumV = ina.summationValue();
+            checkTrue("summationValue() is finite", Double.isFinite(sumV));
+
+            // --- powerValid ---
+            boolean pv = ina.powerValid();
+            checkTrue("powerValid() returns boolean", pv == true || pv == false);
+
+            // --- manufacturerId / dieId ---
+            int mfr = ina.manufacturerId();
+            checkTrue("manufacturerId() == 0x5449", mfr == 0x5449);
+
+            int die = ina.dieId();
+            checkTrue("dieId() == 0x3220", die == 0x3220);
+
+            // --- shutdown / wake ---
+            ina.shutdown();
+            checkTrue("shutdown() accepted", true);
+
+            ina.wake();
+            checkTrue("wake() accepted", true);
+
+            // --- reset ---
+            ina.reset();
+            checkTrue("reset() accepted", true);
+
+        } finally {
+            pi4j.shutdown();
+        }
+
+        System.out.printf("===DONE: %d passed, %d failed===%n", passed, failed);
+        System.exit(failed == 0 ? 0 : 1);
+    }
+}

--- a/jvm/tests/power/ina3221/Ina3221Test.kt
+++ b/jvm/tests/power/ina3221/Ina3221Test.kt
@@ -1,0 +1,110 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.power.Ina3221Full
+
+var passed = 0
+var failed = 0
+
+fun checkTrue(label: String, condition: Boolean) {
+    if (condition) { println("PASS $label"); passed++ }
+    else           { println("FAIL $label"); failed++ }
+}
+
+fun main() {
+    val bus  = System.getenv("I2C_BUS")?.toInt() ?: 1
+    val addr = System.getenv("I2C_ADDR")?.removePrefix("0x")?.removePrefix("0X")?.toInt(16) ?: 0x40
+
+    val pi4j = Pi4J.newAutoContext()
+    try {
+        I2CTransport(pi4j, bus, addr).use { transport ->
+
+            val ina = Ina3221Full(transport)
+
+            // --- Minimal methods: all three channels ---
+            for (ch in 1..3) {
+                val v = ina.voltage(ch)
+                checkTrue("voltage(ch$ch) in 0–26 V", v >= 0.0 && v <= 26.0)
+
+                val sv = ina.shuntVoltage(ch)
+                checkTrue("shuntVoltage(ch$ch) is finite", sv.isFinite())
+
+                val i = ina.current(ch)
+                checkTrue("current(ch$ch) is finite", i.isFinite())
+
+                val p = ina.power(ch)
+                checkTrue("power(ch$ch) is finite", p.isFinite())
+            }
+
+            // --- configure() ---
+            ina.configure(1, 4, 4, Ina3221Full.MODE_SHUNT_BUS_CONT)
+            checkTrue("configure() accepted", true)
+
+            // --- enableChannel / channelEnabled ---
+            ina.enableChannel(1, true)
+            checkTrue("enableChannel(1, true) accepted", true)
+
+            val en = ina.channelEnabled(1)
+            checkTrue("channelEnabled(1) returns boolean", en == true || en == false)
+
+            // --- conversionReady ---
+            val cvrf = ina.conversionReady()
+            checkTrue("conversionReady() returns boolean", cvrf == true || cvrf == false)
+
+            // --- Alert limits ---
+            ina.setCriticalAlert(1, 0.1)
+            checkTrue("setCriticalAlert(1, 0.1) accepted", true)
+
+            ina.setWarningAlert(1, 0.08)
+            checkTrue("setWarningAlert(1, 0.08) accepted", true)
+
+            // --- alertFlags ---
+            val flags = ina.alertFlags()
+            checkTrue("alertFlags() returns int", flags in 0..0xFFFF)
+
+            // --- power-valid limits ---
+            ina.setPowerValidLimits(5.5, 4.5)
+            checkTrue("setPowerValidLimits(5.5, 4.5) accepted", true)
+
+            // --- summation ---
+            ina.setSummationChannels(intArrayOf(1, 2, 3), 0.1)
+            checkTrue("setSummationChannels([1,2,3], 0.1) accepted", true)
+
+            val sumV = ina.summationValue()
+            checkTrue("summationValue() is finite", sumV.isFinite())
+
+            // --- powerValid ---
+            val pv = ina.powerValid()
+            checkTrue("powerValid() returns boolean", pv == true || pv == false)
+
+            // --- manufacturerId / dieId ---
+            val mfr = ina.manufacturerId()
+            checkTrue("manufacturerId() == 0x5449", mfr == 0x5449)
+
+            val die = ina.dieId()
+            checkTrue("dieId() == 0x3220", die == 0x3220)
+
+            // --- shutdown / wake ---
+            ina.shutdown()
+            checkTrue("shutdown() accepted", true)
+
+            ina.wake()
+            checkTrue("wake() accepted", true)
+
+            // --- reset ---
+            ina.reset()
+            checkTrue("reset() accepted", true)
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+
+    println("===DONE: $passed passed, $failed failed===")
+    System.exit(if (failed == 0) 0 else 1)
+}

--- a/jvm/tests/pressure/bmp180/Bmp180Test.groovy
+++ b/jvm/tests/pressure/bmp180/Bmp180Test.groovy
@@ -1,0 +1,76 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-groovy:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import groovy.transform.Field
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.pressure.Bmp180Full
+
+@Field int passed = 0
+@Field int failed = 0
+
+def checkTrue(String label, boolean condition) {
+    if (condition) { println("PASS $label"); passed++ }
+    else           { println("FAIL $label"); failed++ }
+}
+
+int bus = (System.getenv('I2C_BUS') ?: '1').toInteger()
+// BMP180 has a fixed I²C address of 0x77; I2C_ADDR is intentionally ignored.
+int addr = 0x77
+
+def pi4j = Pi4J.newAutoContext()
+try {
+    def transport = new I2CTransport(pi4j, bus, addr)
+    try {
+        def sensor = new Bmp180Full(transport)
+
+        // temperature() — must be in sensor operating range
+        double t = sensor.temperature()
+        checkTrue('temperature() in range [-20, 85] °C', t >= -20.0 && t <= 85.0)
+
+        // pressure() — valid range per datasheet
+        double p = sensor.pressure()
+        checkTrue('pressure() in range [300, 1100] hPa', p >= 300.0 && p <= 1100.0)
+
+        // altitude() — just checks it returns a double without throwing
+        double alt = sensor.altitude()
+        checkTrue('altitude() returns double', !alt.isNaN() && !alt.isInfinite())
+
+        // seaLevelPressure(0.0) — must yield a positive value
+        double slp = sensor.seaLevelPressure(0.0)
+        checkTrue('seaLevelPressure(0.0) > 0', slp > 0.0)
+
+        // chipId() — must return 0x55
+        int id = sensor.chipId()
+        checkTrue('chipId() == 0x55', id == 0x55)
+
+        // setOversampling(3) — must be accepted without exception
+        sensor.setOversampling(3)
+        checkTrue('setOversampling(3) accepted', true)
+
+        // oversampling() — must reflect the value just set
+        int oss = sensor.oversampling()
+        checkTrue('oversampling() == 3', oss == 3)
+
+        // reset() — must complete without exception and keep sensor functional
+        sensor.reset()
+        checkTrue('reset() accepted', true)
+
+        // verify sensor still works after reset
+        double tAfter = sensor.temperature()
+        checkTrue('temperature() after reset in range [-20, 85] °C',
+                  tAfter >= -20.0 && tAfter <= 85.0)
+
+    } finally {
+        transport.close()
+    }
+} finally {
+    pi4j.shutdown()
+}
+
+println("===DONE: ${passed} passed, ${failed} failed===")
+System.exit(failed == 0 ? 0 : 1)

--- a/jvm/tests/pressure/bmp180/Bmp180Test.java
+++ b/jvm/tests/pressure/bmp180/Bmp180Test.java
@@ -1,0 +1,76 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-java:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J;
+import it.uhde.periph.transport.I2CTransport;
+import it.uhde.periph.chips.pressure.Bmp180Full;
+
+public class Bmp180Test {
+
+    static int passed = 0;
+    static int failed = 0;
+
+    static void checkTrue(String label, boolean condition) {
+        if (condition) { System.out.println("PASS " + label); passed++; }
+        else           { System.out.println("FAIL " + label); failed++; }
+    }
+
+    public static void main(String[] args) throws Exception {
+        int bus = Integer.parseInt(System.getenv().getOrDefault("I2C_BUS", "1"));
+        // BMP180 has a fixed I²C address of 0x77; I2C_ADDR is intentionally ignored.
+        int addr = 0x77;
+
+        var pi4j = Pi4J.newAutoContext();
+        try (var transport = new I2CTransport(pi4j, bus, addr)) {
+
+            var sensor = new Bmp180Full(transport);
+
+            // temperature() — must be in sensor operating range
+            double t = sensor.temperature();
+            checkTrue("temperature() in range [-20, 85] °C", t >= -20.0 && t <= 85.0);
+
+            // pressure() — valid range per datasheet
+            double p = sensor.pressure();
+            checkTrue("pressure() in range [300, 1100] hPa", p >= 300.0 && p <= 1100.0);
+
+            // altitude() — just checks it returns a double without throwing
+            double alt = sensor.altitude();
+            checkTrue("altitude() returns double", Double.isFinite(alt));
+
+            // seaLevelPressure(0.0) — must yield a positive value
+            double slp = sensor.seaLevelPressure(0.0);
+            checkTrue("seaLevelPressure(0.0) > 0", slp > 0.0);
+
+            // chipId() — must return 0x55
+            int id = sensor.chipId();
+            checkTrue("chipId() == 0x55", id == 0x55);
+
+            // setOversampling(3) — must be accepted without exception
+            sensor.setOversampling(3);
+            checkTrue("setOversampling(3) accepted", true);
+
+            // oversampling() — must reflect the value just set
+            int oss = sensor.oversampling();
+            checkTrue("oversampling() == 3", oss == 3);
+
+            // reset() — must complete without exception and keep sensor functional
+            sensor.reset();
+            checkTrue("reset() accepted", true);
+
+            // verify sensor still works after reset
+            double tAfter = sensor.temperature();
+            checkTrue("temperature() after reset in range [-20, 85] °C",
+                      tAfter >= -20.0 && tAfter <= 85.0);
+
+        } finally {
+            pi4j.shutdown();
+        }
+
+        System.out.printf("===DONE: %d passed, %d failed===%n", passed, failed);
+        System.exit(failed == 0 ? 0 : 1);
+    }
+}

--- a/jvm/tests/pressure/bmp180/Bmp180Test.kt
+++ b/jvm/tests/pressure/bmp180/Bmp180Test.kt
@@ -1,0 +1,74 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS it.uhde:periph-transport:1.0-SNAPSHOT
+//DEPS it.uhde:periph-kotlin:1.0-SNAPSHOT
+//DEPS com.pi4j:pi4j-core:2.7.0
+//DEPS com.pi4j:pi4j-plugin-raspberrypi:2.7.0
+//DEPS com.pi4j:pi4j-plugin-linuxfs:2.7.0
+
+import com.pi4j.Pi4J
+import it.uhde.periph.transport.I2CTransport
+import it.uhde.periph.chips.pressure.Bmp180Full
+
+var passed = 0
+var failed = 0
+
+fun checkTrue(label: String, condition: Boolean) {
+    if (condition) { println("PASS $label"); passed++ }
+    else           { println("FAIL $label"); failed++ }
+}
+
+fun main() {
+    val bus = System.getenv("I2C_BUS")?.toInt() ?: 1
+    // BMP180 has a fixed I²C address of 0x77; I2C_ADDR is intentionally ignored.
+    val addr = 0x77
+
+    val pi4j = Pi4J.newAutoContext()
+    try {
+        I2CTransport(pi4j, bus, addr).use { transport ->
+
+            val sensor = Bmp180Full(transport)
+
+            // temperature() — must be in sensor operating range
+            val t = sensor.temperature()
+            checkTrue("temperature() in range [-20, 85] °C", t >= -20.0 && t <= 85.0)
+
+            // pressure() — valid range per datasheet
+            val p = sensor.pressure()
+            checkTrue("pressure() in range [300, 1100] hPa", p >= 300.0 && p <= 1100.0)
+
+            // altitude() — just checks it returns a double without throwing
+            val alt = sensor.altitude()
+            checkTrue("altitude() returns double", alt.isFinite())
+
+            // seaLevelPressure(0.0) — must yield a positive value
+            val slp = sensor.seaLevelPressure(0.0)
+            checkTrue("seaLevelPressure(0.0) > 0", slp > 0.0)
+
+            // chipId() — must return 0x55
+            val id = sensor.chipId()
+            checkTrue("chipId() == 0x55", id == 0x55)
+
+            // setOversampling(3) — must be accepted without exception
+            sensor.setOversampling(3)
+            checkTrue("setOversampling(3) accepted", true)
+
+            // oversampling() — must reflect the value just set
+            val oss = sensor.oversampling()
+            checkTrue("oversampling() == 3", oss == 3)
+
+            // reset() — must complete without exception and keep sensor functional
+            sensor.reset()
+            checkTrue("reset() accepted", true)
+
+            // verify sensor still works after reset
+            val tAfter = sensor.temperature()
+            checkTrue("temperature() after reset in range [-20, 85] °C",
+                      tAfter >= -20.0 && tAfter <= 85.0)
+        }
+    } finally {
+        pi4j.shutdown()
+    }
+
+    println("===DONE: $passed passed, $failed failed===")
+    System.exit(if (failed == 0) 0 else 1)
+}

--- a/specs/adc_dac/mcp4725.md
+++ b/specs/adc_dac/mcp4725.md
@@ -229,20 +229,20 @@ Tick each box as the item is committed. The PR may not be opened until every box
 - [x] Examples `jvm/examples/java/adc_dac/mcp4725/Minimal.java` — JBang, Tier-1
 - [x] Examples `jvm/examples/java/adc_dac/mcp4725/Complete.java` — JBang, Tier-1 + Tier-2
 - [x] Examples `jvm/examples/java/adc_dac/mcp4725/Demo.java` — JBang, Tier-1 + Tier-3
-- [ ] Tests `jvm/tests/adc_dac/mcp4725/Mcp4725Test.java` — JBang integration test (Pi hardware)
+- [x] Tests `jvm/tests/adc_dac/mcp4725/Mcp4725Test.java` — JBang integration test (Pi hardware)
 
 ### JVM (Kotlin)
-- [ ] Driver `jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/adc_dac/Mcp4725Minimal.kt`
-- [ ] Driver `jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/adc_dac/Mcp4725Full.kt`
-- [ ] Examples `jvm/examples/kotlin/adc_dac/mcp4725/Minimal.kt` — JBang, Tier-1
-- [ ] Examples `jvm/examples/kotlin/adc_dac/mcp4725/Complete.kt` — JBang, Tier-1 + Tier-2
-- [ ] Examples `jvm/examples/kotlin/adc_dac/mcp4725/Demo.kt` — JBang, Tier-1 + Tier-3
-- [ ] Tests `jvm/tests/adc_dac/mcp4725/Mcp4725Test.kt` — JBang integration test (Pi hardware)
+- [x] Driver `jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/adc_dac/Mcp4725Minimal.kt`
+- [x] Driver `jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/adc_dac/Mcp4725Full.kt`
+- [x] Examples `jvm/examples/kotlin/adc_dac/mcp4725/Minimal.kt` — JBang, Tier-1
+- [x] Examples `jvm/examples/kotlin/adc_dac/mcp4725/Complete.kt` — JBang, Tier-1 + Tier-2
+- [x] Examples `jvm/examples/kotlin/adc_dac/mcp4725/Demo.kt` — JBang, Tier-1 + Tier-3
+- [x] Tests `jvm/tests/adc_dac/mcp4725/Mcp4725Test.kt` — JBang integration test (Pi hardware)
 
 ### JVM (Groovy)
-- [ ] Driver `jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/adc_dac/Mcp4725Minimal.groovy`
-- [ ] Driver `jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/adc_dac/Mcp4725Full.groovy`
-- [ ] Examples `jvm/examples/groovy/adc_dac/mcp4725/Minimal.groovy` — JBang, Tier-1
-- [ ] Examples `jvm/examples/groovy/adc_dac/mcp4725/Complete.groovy` — JBang, Tier-1 + Tier-2
-- [ ] Examples `jvm/examples/groovy/adc_dac/mcp4725/Demo.groovy` — JBang, Tier-1 + Tier-3
-- [ ] Tests `jvm/tests/adc_dac/mcp4725/Mcp4725Test.groovy` — JBang integration test (Pi hardware)
+- [x] Driver `jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/adc_dac/Mcp4725Full.groovy`
+- [x] Driver `jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/adc_dac/Mcp4725Minimal.groovy`
+- [x] Examples `jvm/examples/groovy/adc_dac/mcp4725/Minimal.groovy` — JBang, Tier-1
+- [x] Examples `jvm/examples/groovy/adc_dac/mcp4725/Complete.groovy` — JBang, Tier-1 + Tier-2
+- [x] Examples `jvm/examples/groovy/adc_dac/mcp4725/Demo.groovy` — JBang, Tier-1 + Tier-3
+- [x] Tests `jvm/tests/adc_dac/mcp4725/Mcp4725Test.groovy` — JBang integration test (Pi hardware)

--- a/specs/adc_dac/mcp4725.md
+++ b/specs/adc_dac/mcp4725.md
@@ -222,3 +222,27 @@ Tick each box as the item is committed. The PR may not be opened until every box
 - [ ] Examples `rust/examples/mcp4725_demo/src/main.rs` — Tier-1 + Tier-3
 - [ ] Tests `rust/tests/adc_dac/mcp4725_test/src/main.rs` (Linux)
 - [ ] Tests `rust/tests/adc_dac/mcp4725_test_esp32s3/src/main.rs` (ESP32-S3)
+
+### JVM (Java)
+- [x] Driver `jvm/periph-java/src/main/java/it/uhde/periph/chips/adc_dac/Mcp4725Minimal.java`
+- [x] Driver `jvm/periph-java/src/main/java/it/uhde/periph/chips/adc_dac/Mcp4725Full.java`
+- [x] Examples `jvm/examples/java/adc_dac/mcp4725/Minimal.java` — JBang, Tier-1
+- [x] Examples `jvm/examples/java/adc_dac/mcp4725/Complete.java` — JBang, Tier-1 + Tier-2
+- [x] Examples `jvm/examples/java/adc_dac/mcp4725/Demo.java` — JBang, Tier-1 + Tier-3
+- [ ] Tests `jvm/tests/adc_dac/mcp4725/Mcp4725Test.java` — JBang integration test (Pi hardware)
+
+### JVM (Kotlin)
+- [ ] Driver `jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/adc_dac/Mcp4725Minimal.kt`
+- [ ] Driver `jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/adc_dac/Mcp4725Full.kt`
+- [ ] Examples `jvm/examples/kotlin/adc_dac/mcp4725/Minimal.kt` — JBang, Tier-1
+- [ ] Examples `jvm/examples/kotlin/adc_dac/mcp4725/Complete.kt` — JBang, Tier-1 + Tier-2
+- [ ] Examples `jvm/examples/kotlin/adc_dac/mcp4725/Demo.kt` — JBang, Tier-1 + Tier-3
+- [ ] Tests `jvm/tests/adc_dac/mcp4725/Mcp4725Test.kt` — JBang integration test (Pi hardware)
+
+### JVM (Groovy)
+- [ ] Driver `jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/adc_dac/Mcp4725Minimal.groovy`
+- [ ] Driver `jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/adc_dac/Mcp4725Full.groovy`
+- [ ] Examples `jvm/examples/groovy/adc_dac/mcp4725/Minimal.groovy` — JBang, Tier-1
+- [ ] Examples `jvm/examples/groovy/adc_dac/mcp4725/Complete.groovy` — JBang, Tier-1 + Tier-2
+- [ ] Examples `jvm/examples/groovy/adc_dac/mcp4725/Demo.groovy` — JBang, Tier-1 + Tier-3
+- [ ] Tests `jvm/tests/adc_dac/mcp4725/Mcp4725Test.groovy` — JBang integration test (Pi hardware)

--- a/specs/power/ina219.md
+++ b/specs/power/ina219.md
@@ -257,3 +257,27 @@ A power-supply sanity check: poll the INA219 once per second for 10 seconds, pri
 - INA219 has **no alert mechanism** — there is no Alert pin, no Alert Limit register, no Mask/Enable register. Code that ports cleanly from INA226 must drop the alert API.
 - INA219 has **no ID registers** — driver tests should not check manufacturer/die ID; presence is verified by attempting a register read after configuration.
 - Reset behavior: setting RST resets *all* registers (including Calibration) to power-on defaults. Drivers must re-write the Calibration Register after `reset()`. The Full driver should also restore the most recent user-supplied Configuration if `configure()` was called.
+
+### JVM (Java)
+- [x] Driver `jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina219Minimal.java`
+- [x] Driver `jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina219Full.java`
+- [x] Examples `jvm/examples/java/power/ina219/Minimal.java` — JBang, Tier-1
+- [x] Examples `jvm/examples/java/power/ina219/Complete.java` — JBang, Tier-1 + Tier-2
+- [x] Examples `jvm/examples/java/power/ina219/Demo.java` — JBang, Tier-1 + Tier-3
+- [x] Tests `jvm/tests/power/ina219/Ina219Test.java` — JBang integration test (Pi hardware)
+
+### JVM (Kotlin)
+- [x] Driver `jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina219Minimal.kt`
+- [x] Driver `jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina219Full.kt`
+- [x] Examples `jvm/examples/kotlin/power/ina219/Minimal.kt` — JBang, Tier-1
+- [x] Examples `jvm/examples/kotlin/power/ina219/Complete.kt` — JBang, Tier-1 + Tier-2
+- [x] Examples `jvm/examples/kotlin/power/ina219/Demo.kt` — JBang, Tier-1 + Tier-3
+- [x] Tests `jvm/tests/power/ina219/Ina219Test.kt` — JBang integration test (Pi hardware)
+
+### JVM (Groovy)
+- [x] Driver `jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina219Minimal.groovy`
+- [x] Driver `jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina219Full.groovy`
+- [x] Examples `jvm/examples/groovy/power/ina219/Minimal.groovy` — JBang, Tier-1
+- [x] Examples `jvm/examples/groovy/power/ina219/Complete.groovy` — JBang, Tier-1 + Tier-2
+- [x] Examples `jvm/examples/groovy/power/ina219/Demo.groovy` — JBang, Tier-1 + Tier-3
+- [x] Tests `jvm/tests/power/ina219/Ina219Test.groovy` — JBang integration test (Pi hardware)

--- a/specs/power/ina226.md
+++ b/specs/power/ina226.md
@@ -284,3 +284,27 @@ Tick each box as the item is committed. The PR may not be opened until every box
 - [ ] Examples `rust/examples/ina226_demo/src/main.rs` — Tier-1 + Tier-3
 - [x] Tests `rust/tests/power/ina226_test/src/main.rs` (Linux)
 - [x] Tests `rust/tests/power/ina226_test_esp32s3/src/main.rs` (ESP32-S3)
+
+### JVM (Java)
+- [x] Driver `jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina226Minimal.java`
+- [x] Driver `jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina226Full.java`
+- [x] Examples `jvm/examples/java/power/ina226/Minimal.java` — JBang, Tier-1
+- [x] Examples `jvm/examples/java/power/ina226/Complete.java` — JBang, Tier-1 + Tier-2
+- [x] Examples `jvm/examples/java/power/ina226/Demo.java` — JBang, Tier-1 + Tier-3
+- [x] Tests `jvm/tests/power/ina226/Ina226Test.java` — JBang integration test (Pi hardware)
+
+### JVM (Kotlin)
+- [x] Driver `jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina226Minimal.kt`
+- [x] Driver `jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina226Full.kt`
+- [x] Examples `jvm/examples/kotlin/power/ina226/Minimal.kt` — JBang, Tier-1
+- [x] Examples `jvm/examples/kotlin/power/ina226/Complete.kt` — JBang, Tier-1 + Tier-2
+- [x] Examples `jvm/examples/kotlin/power/ina226/Demo.kt` — JBang, Tier-1 + Tier-3
+- [x] Tests `jvm/tests/power/ina226/Ina226Test.kt` — JBang integration test (Pi hardware)
+
+### JVM (Groovy)
+- [x] Driver `jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina226Minimal.groovy`
+- [x] Driver `jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina226Full.groovy`
+- [x] Examples `jvm/examples/groovy/power/ina226/Minimal.groovy` — JBang, Tier-1
+- [x] Examples `jvm/examples/groovy/power/ina226/Complete.groovy` — JBang, Tier-1 + Tier-2
+- [x] Examples `jvm/examples/groovy/power/ina226/Demo.groovy` — JBang, Tier-1 + Tier-3
+- [x] Tests `jvm/tests/power/ina226/Ina226Test.groovy` — JBang integration test (Pi hardware)

--- a/specs/power/ina3221.md
+++ b/specs/power/ina3221.md
@@ -363,3 +363,27 @@ Tick each box as the item is committed. The PR may not be opened until every box
 - [ ] Examples `rust/examples/ina3221_demo/src/main.rs` — Tier-1 + Tier-3
 - [ ] Tests `rust/tests/power/ina3221_test/src/main.rs` (Linux)
 - [ ] Tests `rust/tests/power/ina3221_test_esp32s3/src/main.rs` (ESP32-S3)
+
+### JVM (Java)
+- [x] Driver `jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina3221Minimal.java`
+- [x] Driver `jvm/periph-java/src/main/java/it/uhde/periph/chips/power/Ina3221Full.java`
+- [x] Examples `jvm/examples/java/power/ina3221/Minimal.java` — JBang, Tier-1
+- [x] Examples `jvm/examples/java/power/ina3221/Complete.java` — JBang, Tier-1 + Tier-2
+- [x] Examples `jvm/examples/java/power/ina3221/Demo.java` — JBang, Tier-1 + Tier-3
+- [x] Tests `jvm/tests/power/ina3221/Ina3221Test.java` — JBang integration test (Pi hardware)
+
+### JVM (Kotlin)
+- [x] Driver `jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina3221Minimal.kt`
+- [x] Driver `jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/power/Ina3221Full.kt`
+- [x] Examples `jvm/examples/kotlin/power/ina3221/Minimal.kt` — JBang, Tier-1
+- [x] Examples `jvm/examples/kotlin/power/ina3221/Complete.kt` — JBang, Tier-1 + Tier-2
+- [x] Examples `jvm/examples/kotlin/power/ina3221/Demo.kt` — JBang, Tier-1 + Tier-3
+- [x] Tests `jvm/tests/power/ina3221/Ina3221Test.kt` — JBang integration test (Pi hardware)
+
+### JVM (Groovy)
+- [x] Driver `jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina3221Minimal.groovy`
+- [x] Driver `jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/power/Ina3221Full.groovy`
+- [x] Examples `jvm/examples/groovy/power/ina3221/Minimal.groovy` — JBang, Tier-1
+- [x] Examples `jvm/examples/groovy/power/ina3221/Complete.groovy` — JBang, Tier-1 + Tier-2
+- [x] Examples `jvm/examples/groovy/power/ina3221/Demo.groovy` — JBang, Tier-1 + Tier-3
+- [x] Tests `jvm/tests/power/ina3221/Ina3221Test.groovy` — JBang integration test (Pi hardware)

--- a/specs/pressure/bmp180.md
+++ b/specs/pressure/bmp180.md
@@ -272,3 +272,27 @@ Tick each box as the item is committed. The PR may not be opened until every box
 - [ ] Examples `rust/examples/bmp180_demo/src/main.rs` — Tier-1 + Tier-3
 - [ ] Tests `rust/tests/pressure/bmp180_test/src/main.rs` (Linux)
 - [ ] Tests `rust/tests/pressure/bmp180_test_esp32s3/src/main.rs` (ESP32-S3)
+
+### JVM (Java)
+- [x] Driver `jvm/periph-java/src/main/java/it/uhde/periph/chips/pressure/Bmp180Minimal.java`
+- [x] Driver `jvm/periph-java/src/main/java/it/uhde/periph/chips/pressure/Bmp180Full.java`
+- [x] Examples `jvm/examples/java/pressure/bmp180/Minimal.java` — JBang, Tier-1
+- [x] Examples `jvm/examples/java/pressure/bmp180/Complete.java` — JBang, Tier-1 + Tier-2
+- [x] Examples `jvm/examples/java/pressure/bmp180/Demo.java` — JBang, Tier-1 + Tier-3
+- [x] Tests `jvm/tests/pressure/bmp180/Bmp180Test.java` — JBang integration test (Pi hardware)
+
+### JVM (Kotlin)
+- [x] Driver `jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/pressure/Bmp180Minimal.kt`
+- [x] Driver `jvm/periph-kotlin/src/main/kotlin/it/uhde/periph/chips/pressure/Bmp180Full.kt`
+- [x] Examples `jvm/examples/kotlin/pressure/bmp180/Minimal.kt` — JBang, Tier-1
+- [x] Examples `jvm/examples/kotlin/pressure/bmp180/Complete.kt` — JBang, Tier-1 + Tier-2
+- [x] Examples `jvm/examples/kotlin/pressure/bmp180/Demo.kt` — JBang, Tier-1 + Tier-3
+- [x] Tests `jvm/tests/pressure/bmp180/Bmp180Test.kt` — JBang integration test (Pi hardware)
+
+### JVM (Groovy)
+- [x] Driver `jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/pressure/Bmp180Minimal.groovy`
+- [x] Driver `jvm/periph-groovy/src/main/groovy/it/uhde/periph/chips/pressure/Bmp180Full.groovy`
+- [x] Examples `jvm/examples/groovy/pressure/bmp180/Minimal.groovy` — JBang, Tier-1
+- [x] Examples `jvm/examples/groovy/pressure/bmp180/Complete.groovy` — JBang, Tier-1 + Tier-2
+- [x] Examples `jvm/examples/groovy/pressure/bmp180/Demo.groovy` — JBang, Tier-1 + Tier-3
+- [x] Tests `jvm/tests/pressure/bmp180/Bmp180Test.groovy` — JBang integration test (Pi hardware)


### PR DESCRIPTION
## Summary

- Adds full JVM target (Java, Kotlin, Groovy) for Raspberry Pi via Pi4J 2.7.0
- Implements I²C transport (`periph-transport`) and five chip drivers across all three JVM languages: MCP4725, INA219, INA226, INA3221, BMP180
- Each chip has Minimal + Full driver classes, three tiered JBang examples (Minimal/Complete/Demo), and hardware integration test scripts
- Maven multi-module build (`periph-transport`, `periph-java`, `periph-kotlin`, `periph-groovy`); JBang resolves SNAPSHOT deps at runtime on the Pi
- Test runner `jvm/test.sh` supports all three languages via `--lang java|kotlin|groovy`

## Chips

| Chip | Category | Languages |
|------|----------|-----------|
| MCP4725 | adc_dac | Java, Kotlin, Groovy |
| INA219 | power | Java, Kotlin, Groovy |
| INA226 | power | Java, Kotlin, Groovy |
| INA3221 | power | Java, Kotlin, Groovy |
| BMP180 | pressure | Java, Kotlin, Groovy |

## Test plan

- [ ] `cd jvm && mvn install` builds cleanly (verified locally)
- [ ] `./jvm/test.sh adc_dac/mcp4725` passes on Pi with MCP4725 connected (verified)
- [ ] `./jvm/test.sh adc_dac/mcp4725 --lang kotlin` passes
- [ ] `./jvm/test.sh adc_dac/mcp4725 --lang groovy` passes
- [ ] Hardware tests for INA219/INA226/INA3221/BMP180 require respective chips connected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)