### PR TITLE
ci: add Java compile job for JVM modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,26 @@ jobs:
                    if (!m.INA226Minimal || !m.INA226Full) process.exit(1)"
 
   # -----------------------------------------------------------------------
+  # Java / Kotlin / Groovy — compile-only (no hardware required)
+  # -----------------------------------------------------------------------
+  java:
+    name: Java compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Compile JVM modules
+        run: mvn install --batch-mode --no-transfer-progress -DskipTests
+        working-directory: jvm
+
+  # -----------------------------------------------------------------------
   # Rust — compile-only (no hardware required)
   # -----------------------------------------------------------------------
   rust:


### PR DESCRIPTION
## Summary

- Adds `java` CI job to `.github/workflows/ci.yml`
- Compiles the `jvm/` multi-module Maven project (Java, Kotlin, Groovy) on every push to main and every PR
- Uses Java 17 Temurin with built-in Maven dependency caching

🤖 Generated with [Claude Code](https://claude.ai/claude-code)