### PR TITLE
docs(readme): remove NeoPixel transport and WS2812B chip rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ A multi-language library of drivers for peripheral chips — sensors, actuators,
 | I²C | Implemented |
 | SPI | Implemented |
 | SMBus | Implemented |
-| NeoPixel (WS2812B / single-wire NZR) | Spec ready, implementation pending |
 
 ## Structure
 
@@ -82,7 +81,6 @@ import it.uhde.periph.chips.power.Ina226Minimal
 | INA226 | Power monitor | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | Python · C++ · Node.js · Node-RED · Rust · JVM |
 | INA3221 | Power monitor (3-ch) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | Python · C++ · Node.js · Node-RED · Rust · JVM |
 | MCP4725 | 12-bit DAC | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | Python · C++ · Node.js · Node-RED · Rust · JVM |
-| WS2812B | LED (addressable RGB) | ✓ | ✓ | ✓ | ✓ | ✓ | | Python · C++ · Node.js · Node-RED · Rust |
 
 More chips are in progress — see the [open issues](../../issues) for what's being specced and implemented.
 


### PR DESCRIPTION
Removes two rows that were added beyond the scope of the JVM README update.